### PR TITLE
Fixes #4 and some micro-optimizations

### DIFF
--- a/compile/GdalConfigureAll.cs
+++ b/compile/GdalConfigureAll.cs
@@ -12,10 +12,17 @@ namespace MaxRev.Gdal.Core
     public static class GdalBase
     {
         /// <summary>
+        /// Shows if gdal is already initialized.
+        /// </summary>
+        public static bool IsConfigured { get; set; }
+
+        /// <summary>
         /// Setups gdalplugins and calls Gdal.AllRegister(), Ogr.RegisterAll(), Proj6.Configure(). 
         /// </summary>
         public static void ConfigureAll()
         {
+            if (IsConfigured) return;
+
             var thisName = Assembly.GetExecutingAssembly().FullName;
             try
             {
@@ -100,6 +107,8 @@ namespace MaxRev.Gdal.Core
                 Console.WriteLine(ex);
                 throw ex;
             }
+
+            IsConfigured = true;
         }
     }
 }

--- a/compile/GdalConfigureAll.cs
+++ b/compile/GdalConfigureAll.cs
@@ -45,8 +45,6 @@ namespace MaxRev.Gdal.Core
 
                     var executingDir = new FileInfo(Assembly.GetEntryAssembly().Location).Directory;
                     var targetDir = new DirectoryInfo(Path.Combine(executingDir.FullName));
-
-                    string name = targetDir.FullName;
                     targetDir.Create();
 
 
@@ -79,12 +77,12 @@ namespace MaxRev.Gdal.Core
                         }
                         else
                         {
-                            Console.WriteLine(thisName + ": Can't find runtime libraries");
+                            Console.WriteLine($"{thisName}: Can't find runtime libraries");
                         }
                     }
                     else
                     {
-                        var drs = executingDir.GetFiles("gdal_*.dll").Where(x => !x.Name.Contains("wrap"));
+                        var drs = executingDir.EnumerateFiles("gdal_*.dll").Where(x => !x.Name.Contains("wrap"));
                         var tr = Path.Combine(targetDir.FullName, "gdalplugins");
                         Directory.CreateDirectory(tr);
                         foreach (var dr in drs)
@@ -105,7 +103,7 @@ namespace MaxRev.Gdal.Core
             {
                 Console.WriteLine("Error in " + thisName);
                 Console.WriteLine(ex);
-                throw ex;
+                throw;
             }
 
             IsConfigured = true;


### PR DESCRIPTION
Closes #4. Now re-initializations would not run.
Also replaced `GetFiles()` method with more performant `EnumerateFiles()` and removed unnecessary exception variable near rethrow statement (aka `throw ex`).