### PR TITLE
Patch 310, fixes unmanaged caller assembly search

### DIFF
--- a/compile/Proj6Configure.cs
+++ b/compile/Proj6Configure.cs
@@ -35,9 +35,9 @@ namespace MaxRev.Gdal.Core
 
                 const string libshared = "maxrev.gdal.core.libshared";
                 var runtimes = $"runtimes/{rid}/native";
-
+                var entryAsm = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
                 var entryRoot =
-                    new FileInfo(Assembly.GetEntryAssembly()!.Location)
+                    new FileInfo(entryAsm!.Location)
                         .Directory!.FullName;
                 var executingRoot =
                     new FileInfo(Assembly.GetExecutingAssembly()!.Location)
@@ -64,6 +64,7 @@ namespace MaxRev.Gdal.Core
                     runtimes,
                     libshared,
                 }.Select(x => new DirectoryInfo(x).FullName);
+                
                 string found = default;
                 foreach (var item in possibleLocations)
                 {

--- a/gdalcore.loader.csproj
+++ b/gdalcore.loader.csproj
@@ -12,7 +12,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>   
     <RepositoryUrl>https://github.com/MaxRev-Dev/gdal.netcore</RepositoryUrl>
-    <Version>3.2.0.300</Version>
+    <Version>3.2.0.310</Version>
     <Description>GDAL (3.2.0) bindings for dotnet core (now linux-x64 and win-x64).
 Bridge between gdal and netcore.
 Use dependency package for target runtime to get drivers.

--- a/test/GdalCore-XUnit/GdalCore-XUnit.csproj
+++ b/test/GdalCore-XUnit/GdalCore-XUnit.csproj
@@ -7,7 +7,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.2.0.300" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.2.0.310" />
     <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.2.0.300" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.2.0.300" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/test/GdalCore-XUnit/GdalCore-XUnit.csproj
+++ b/test/GdalCore-XUnit/GdalCore-XUnit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="MaxRev.Gdal.Core" Version="3.2.0.310" />
     <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.2.0.300" />
-    <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.2.0.300" />
+    <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.2.0.300" /> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/GdalCoreTest/GdalCoreTest.csproj
+++ b/test/GdalCoreTest/GdalCoreTest.csproj
@@ -7,7 +7,7 @@
     <StartupObject>GdalCoreTest.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.2.0.300" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.2.0.310" />
     <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.2.0.300" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.2.0.300" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13"/>


### PR DESCRIPTION
This PR, should fix #40 unmanaged caller assembly content lookup on startup configuration in Core module.