### PR TITLE
Filter linux system dependencies on packaging

### DIFF
--- a/gdalcore.linuxruntime.csproj
+++ b/gdalcore.linuxruntime.csproj
@@ -12,7 +12,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/MaxRev-Dev/gdal.netcore</RepositoryUrl>
-    <Version>3.3.3.110</Version>
+    <Version>3.3.3.120</Version>
     <Description>GDAL (3.3.3) minimal libraries package. 
 Drivers included PROJ (7.2.1), GEOS (3.9.0), SQLITE3, CURL, JPEG, PNG, HDF4, HDF5
 Targets linux-x64 runtime. Target Frameworks: netstandard[2.1|2.0], netcoreapp[2.1,3.1], net5.0

--- a/test/GdalCore-AzureFunctions/GdalCore-AzureFunctions.csproj
+++ b/test/GdalCore-AzureFunctions/GdalCore-AzureFunctions.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="MaxRev.Gdal.Core" Version="3.3.3.110" />
-    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.3.3.110" />
+    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.3.3.120" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.3.3.110" />
   </ItemGroup>
   <ItemGroup>

--- a/test/GdalCore-XUnit/GdalCore-XUnit.csproj
+++ b/test/GdalCore-XUnit/GdalCore-XUnit.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MaxRev.Gdal.Core" Version="3.3.3.110" />
-    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.3.3.110" />
+    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.3.3.120" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.3.3.110" /> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/GdalCoreTest/GdalCoreTest.csproj
+++ b/test/GdalCoreTest/GdalCoreTest.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MaxRev.Gdal.Core" Version="3.3.3.110" />
-    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.3.3.110" />
+    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.3.3.120" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.3.3.110" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
   </ItemGroup>

--- a/unix/GNUmakefile
+++ b/unix/GNUmakefile
@@ -101,7 +101,9 @@ makesolocal:
 	$(foreach lib, $(local_o),  g++ -shared -o $(OUTPUT)/$(basename $(lib)).so $(lib) $(OUTPUT)/libgdal.$(GDAL_SO_VER_);${\n})
 	
 copyalldepso:
-	ldd $(BUILD_BASE_LIB)/libgdal.so | grep "=> /" | awk '{print $$3}' | xargs -I {} cp -v {} $(OUTPUT) 
+#   include all deps installed in this repo
+#   and some external dependencies (odbc,ltdl)
+	ldd "$(BUILD_BASE_LIB)/libgdal.so" | grep -E "$(ROOTDIR_)/build-unix|odbc|ltdl" | awk '{print $$3}' | xargs -I {} cp -v {} $(OUTPUT) 
 	
 copyprojdb:
 	-mkdir -p $(LIBSHARED)


### PR DESCRIPTION
LD loader on Fedora's distro tries to load some system libraries from the runtime package. But the diversity between runtimes reveals some missing symbols because we tried to load native dependencies from another distro.
The fix is simple - all system libraries should be removed from packaging.