### PR TITLE
Add checks for missing permissions on drivers copy

### DIFF
--- a/compile/GdalConfigureAll.cs
+++ b/compile/GdalConfigureAll.cs
@@ -104,20 +104,26 @@ namespace MaxRev.Gdal.Core
             (DirectoryInfo targetDir, DirectoryInfo executingDir, out string targetDrivers)
         {
             var drivers = executingDir.GetGdalPlugins();
-            
+
             if (!drivers.Any())
-            { 
+            {
                 throw new InvalidOperationException("Can't find drivers in executing directory.");
             }
 
             targetDrivers = Path.Combine(targetDir.FullName, "gdalplugins");
-
-            MoveDriversTo(drivers, targetDrivers);
+            
+            // check if this folder is already populated with drivers
+            var targetDirInfo = new DirectoryInfo(targetDrivers);
+            if (!targetDirInfo.Exists ||
+                !targetDirInfo.EnumerateFiles().Any())
+            {
+                MoveDriversTo(drivers, ref targetDrivers);
+            }
 
             return true;
         }
 
-        private static void MoveDriversTo(IEnumerable<FileInfo> drivers, string targetDrivers)
+        private static void MoveDriversTo(IEnumerable<FileInfo> drivers, ref string targetDrivers)
         {
             try
             {
@@ -161,8 +167,8 @@ namespace MaxRev.Gdal.Core
 
             targetOrigin = Path.Combine(originDir.FullName, "gdalplugins");
             if (Directory.Exists(targetOrigin) && Directory.EnumerateFiles(targetOrigin).Any())
-                return true; 
-            
+                return true;
+
             return false;
         }
 

--- a/gdalcore.loader.csproj
+++ b/gdalcore.loader.csproj
@@ -14,7 +14,7 @@
     <RepositoryType>git</RepositoryType>
     <LangVersion>10.0</LangVersion>
     <RepositoryUrl>https://github.com/MaxRev-Dev/gdal.netcore</RepositoryUrl>
-    <Version>3.3.3.110</Version>
+    <Version>3.3.3.120</Version>
     <Description>
       GDAL (3.3.3) bindings for dotnet core (now linux-x64 and win-x64).
       Bridge between gdal and netcore.
@@ -27,8 +27,7 @@
       - built on CentOS 7 (glibc - 2.17)
       - GDAL Version 3.3.3
       - built with vcpkg
-      - PROJ.DB now ships with target runtime
-      - fixed proj.db search on azure functions
+      - fixed drivers lookup algorithm
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/test/GdalCore-XUnit/GdalCore-XUnit.csproj
+++ b/test/GdalCore-XUnit/GdalCore-XUnit.csproj
@@ -8,7 +8,7 @@
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.3.3.110" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.3.3.120" />
     <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.3.3.120" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.3.3.110" /> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />


### PR DESCRIPTION
This should fix driver copy logic in configurator when the app is installed withing a root folder, missing writable permissions.