### PR TITLE
Release 3.6.1

### DIFF
--- a/gdalcore.linuxruntime.csproj
+++ b/gdalcore.linuxruntime.csproj
@@ -12,17 +12,17 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/MaxRev-Dev/gdal.netcore</RepositoryUrl>
-    <Version>3.6.0.110</Version>
-    <Description>GDAL (3.6.0) minimal libraries package. 
+    <Version>3.6.1.100</Version>
+    <Description>GDAL (3.6.1) minimal libraries package. 
 Drivers included PROJ (7.2.1), GEOS (3.11.1), SQLITE3, CURL, JPEG, PNG, HDF4, HDF5
 Targets linux-x64 runtime. Target Frameworks: netstandard[2.1|2.0], netcoreapp[2.1,3.1], net6.0, net7.0
 </Description>
     <AssemblyName>MaxRev.Gdal.LinuxRuntime.Minimal</AssemblyName>
     <PackageReleaseNotes>
-- GDAL 3.6.0
+- Bug fix release.
+- GDAL 3.6.1
 - targets .NET6 LTS, .NET7 
-- GEOS 3.11.1
-- Includes missing MySQL driver</PackageReleaseNotes>
+- GEOS 3.11.1</PackageReleaseNotes>
   </PropertyGroup>
   
   <ItemGroup> 

--- a/gdalcore.loader.csproj
+++ b/gdalcore.loader.csproj
@@ -14,9 +14,9 @@
     <RepositoryType>git</RepositoryType>
     <LangVersion>10.0</LangVersion>
     <RepositoryUrl>https://github.com/MaxRev-Dev/gdal.netcore</RepositoryUrl>
-    <Version>3.6.0.100</Version>
+    <Version>3.6.1.100</Version>
     <Description>
-      GDAL (3.6.0) bindings for dotnet core (now linux-x64 and win-x64).
+      GDAL (3.6.1) bindings for dotnet core (now linux-x64 and win-x64).
       Bridge between gdal and netcore.
       Use dependency package for target runtime to get drivers.
       Works in docker containers without pkg installations!!
@@ -24,7 +24,7 @@
     </Description>
     <RootNamespace></RootNamespace>
     <PackageReleaseNotes>
-      - GDAL Version 3.6.0
+      - GDAL Version 3.6.1
       - built with VCPKG
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/gdalcore.windowsruntime.csproj
+++ b/gdalcore.windowsruntime.csproj
@@ -12,14 +12,14 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/MaxRev-Dev/gdal.netcore</RepositoryUrl>
-    <Version>3.6.0.100</Version>
-    <Description>GDAL (3.6.0) minimal libraries package. 
+    <Version>3.6.1.100</Version>
+    <Description>GDAL (3.6.1) minimal libraries package. 
 Drivers included PROJ (7.2.1), GEOS (3.11.1), SQLITE3, CURL, JPEG, PNG, HDF4, HDF5
 Targets win-x64 runtime. Target Frameworks: netstandard[2.1|2.0], netcoreapp[2.1,3.1], net6.0, net7.0
 </Description>
     <AssemblyName>MaxRev.Gdal.WindowsRuntime.Minimal</AssemblyName> 
     <PackageReleaseNotes>
-- GDAL 3.6.0
+- GDAL 3.6.1
 - targets .NET6 LTS, .NET7 
 - GEOS 3.11.1</PackageReleaseNotes>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> 

--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -10,11 +10,11 @@ BUILD_ROOT=$(ROOTDIR_)/build-$(BASE_RUNTIME_RID)
 
 GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 GDAL_REPO=https://github.com/OSGeo/gdal.git
-GDAL_COMMIT_VER=0c6a97a28b31934b20df7df701e2c57fde181e25 # v3.6.0 - Dec 11, 2022
+GDAL_COMMIT_VER=tags/v3.6.1 # v3.6.1 - Dec 14, 2022
 
 PROJ_ROOT=$(BUILD_ROOT)/proj-source
 PROJ_REPO=https://github.com/OSGeo/PROJ.git
-PROJ_COMMIT_VER=cc2d1758acedd2886241967be355b88a7b9d09fe # 7.2.1 - Mar, 2021
+PROJ_COMMIT_VER=tags/7.2.1 # 7.2.1 - Mar, 2021
 
 # ---------------------- VCPKG ----------------------
 

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.100" />
-    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.6.0.110" />
+    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.6.1.100" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.1.100" /> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
@@ -8,9 +8,9 @@
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.0.100" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.100" />
     <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.6.0.110" />
-    <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.0.100" /> 
+    <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.1.100" /> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj
@@ -9,9 +9,9 @@
     <RootNamespace>MaxRev.Gdal.Core.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.0.100" />
-    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.6.0.110" />
-    <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.0-dev003" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.100" />
+    <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.6.1.100" />
+    <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.1.100" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
   </ItemGroup>
 </Project>

--- a/win/fetch-makefile.vc
+++ b/win/fetch-makefile.vc
@@ -11,7 +11,7 @@ fetch-gdal:
     git clone $(GDAL_REPO) $(GDAL_ROOT_BASE)
 !ENDIF
 	cd $(GDAL_ROOT)
-	git fetch
+	git fetch --all --tags
 	git checkout -fq $(GDAL_COMMIT_VER) 
 	git reset --hard
 	$(GIT_CLEAN)
@@ -22,7 +22,7 @@ fetch-proj:
     git clone $(PROJ_REPO) $(PROJ_ROOT)
 !ENDIF
 	cd $(PROJ_ROOT)
-	git fetch
+	git fetch --all --tags
 	git checkout -fq $(PROJ_COMMIT_VER)
 	git reset --hard
 	$(GIT_CLEAN)

--- a/win/partials.psm1
+++ b/win/partials.psm1
@@ -118,6 +118,7 @@ function Install-Proj {
     $env:PROJ_SOURCE = "$env:BUILD_ROOT\proj-source"
     Write-BuildInfo "Checking out PROJ repo..."
 
+    Set-Location "$PSScriptRoot"
     nmake -f fetch-makefile.vc fetch-proj
     #Get-CloneAndCheckoutCleanGitRepo $env:PROJ_REPO $env:PROJ_COMMIT_VER $env:PROJ_SOURCE
  
@@ -135,7 +136,7 @@ function Install-Proj {
     New-FolderIfNotExistsAndSetCurrentLocation $env:ProjCmakeBuild
 
     cmake -G $env:VS_VERSION -A $env:CMAKE_ARCHITECTURE $env:PROJ_SOURCE `
-        -DCMAKE_INSTALL_PREFIX=$env:PROJ_INSTALL_DIR `
+        -DCMAKE_INSTALL_PREFIX="$env:PROJ_INSTALL_DIR" `
         -DCMAKE_BUILD_TYPE=Release -Wno-dev `
         -DPROJ_TESTS=OFF -DBUILD_LIBPROJ_SHARED=ON `
         -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
@@ -190,6 +191,7 @@ function Build-Gdal {
         Remove-Item -Path $env:GdalCmakeBuild -Recurse -Force
     }
     
+    Set-Location "$PSScriptRoot"
     nmake -f fetch-makefile.vc fetch-gdal
     #Get-CloneAndCheckoutCleanGitRepo $env:GDAL_REPO $env:GDAL_COMMIT_VER "$env:GDAL_SOURCE"
 
@@ -210,7 +212,7 @@ function Build-Gdal {
     # PATCH 2: apply patch to cmake pipeline. remove redundant compile steps
     git apply "$PSScriptRoot\..\shared\patch\CMakeLists.txt.patch"
 
-    New-FolderIfNotExistsAndSetCurrentLocation $env:GdalCmakeBuild  
+    New-FolderIfNotExistsAndSetCurrentLocation $env:GdalCmakeBuild
 
     cmake -G $env:VS_VERSION -A $env:CMAKE_ARCHITECTURE "$env:GDAL_SOURCE" `
         $env:CMAKE_INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release -Wno-dev `
@@ -233,12 +235,12 @@ function Build-CsharpBindings {
     
     Set-Location $PSScriptRoot
     
-    nmake -f "$PSScriptRoot\collect-deps-makefile.vc"
+    nmake -f collect-deps-makefile.vc
     
     if ($isDebug) {
-        nmake -f "$PSScriptRoot\publish-makefile.vc" pack-dev DEBUG=1
+        nmake -f publish-makefile.vc pack-dev DEBUG=1
     }
     else {
-        nmake -f "$PSScriptRoot\publish-makefile.vc" pack
+        nmake -f publish-makefile.vc pack
     }
 }

--- a/win/push-packages.ps1
+++ b/win/push-packages.ps1
@@ -1,0 +1,7 @@
+dotnet nuget push ../nuget/MaxRev.Gdal.Core.$env:VERSION.nupkg -s nuget.org -k $env:API_KEY_NUGET --skip-duplicate
+dotnet nuget push ../nuget/MaxRev.Gdal.LinuxRuntime.Minimal.$env:VERSION.nupkg -s nuget.org -k $env:API_KEY_NUGET --skip-duplicate
+dotnet nuget push ../nuget/MaxRev.Gdal.WindowsRuntime.Minimal.$env:VERSION.nupkg -s nuget.org -k $env:API_KEY_NUGET --skip-duplicate
+
+dotnet nuget push ../nuget/MaxRev.Gdal.Core.$env:VERSION.nupkg -s github -k $env:API_KEY_GITHUB --skip-duplicate
+dotnet nuget push ../nuget/MaxRev.Gdal.LinuxRuntime.Minimal.$env:VERSION.nupkg -s github -k $env:API_KEY_GITHUB --skip-duplicate
+dotnet nuget push ../nuget/MaxRev.Gdal.WindowsRuntime.Minimal.$env:VERSION.nupkg -s github -k $env:API_KEY_GITHUB --skip-duplicate


### PR DESCRIPTION
## _Warning: GDAL 3.6.0 version has been official retracted and superseded per 3.6.1_
Bug fix release.
More info: https://github.com/OSGeo/gdal/blob/v3.6.1/NEWS.md