### PR TITLE
Patch: Grid shifts and other GDAL data packaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ NuGet: [MaxRev.Gdal.WindowsRuntime.Minimal](https://www.nuget.org/packages/MaxRe
   * [About build configuration](#about-build-configuration)
   * [Building runtime libraries](#building-runtime-libraries)
   * [FAQ](#faq)
-      - [Q: Packages do not work on CentOS 7, Ubuntu 18.04](#q-packages-do-not-work-on-centos-7-ubuntu-1804)
+      - [Q: Packages do not work on CentOS 7, Ubuntu 18.04](#q-packages-does-not-work-on-centos-7-ubuntu-1804)
       - [Q: Projections are not working as expected](#q-projections-are-not-working-as-expected)
       - [Q: Some drivers complain about missing data files](#q-some-drivers-complain-about-missing-data-files)
       - [Q: Missing {some} drivers, can you add more?](#q-missing--some--drivers--can-you-add-more-)
@@ -93,25 +93,25 @@ Detailed guide is here - [unix](unix/).
 
 ## About build configuration
 
-Current version targets **GDAL 3.6.1** with **minimal drivers**. What stands for 'minimal' - drivers that require no additional dependencies (mainly boost). For example, `MySQL` driver is not included, because it requires 15+ boost deps. Same goes for `Poppler` driver. They can be packaged upon a request.
+The current version targets **GDAL 3.6.1** with **minimal drivers**. What stands for 'minimal' - drivers that require no additional dependencies (mainly boost). For example, `MySQL` driver is not included, because it requires 15+ boost deps. Same goes for `Poppler` driver. They can be packaged upon request.
 
-Drivers included PROJ(7.2.1), GEOS(3.11.1) and more than 200 other drivers.
-To view full list of drivers, run view the full list of drivers with GDAL's API or see property `DriversInCurrentVersion` [here](tests/MaxRev.Gdal.Core.Tests.XUnit/CommonTests.cs).
+Drivers included PROJ(7.2.1), GEOS(3.11.1), and more than 200 other drivers.
+To view full list of drivers, To view the complete list of drivers, you can view the full list with GDAL's API or see property `DriversInCurrentVersion` [here](tests/MaxRev.Gdal.Core.Tests.XUnit/CommonTests.cs).
 
-**NOTE**: Windows and Linux drivers availability may differ, ask me of a specific driver for runtime. Please issue, if I forgot to mention any packages.
+**NOTE**: Windows and Linux drivers availability may differ. Ask me about a specific driver for runtime. Please issue if I need to mention any packages.
 
 ## Building runtime libraries
 
-Current version is targeting **GDAL 3.6.1** version. Each runtime has to be build separately, but this can be done concurrently as they are using different contexts (build folders). Main operating bindings (in gdal.core package) are build from **windows**.
+Current version is targeting **GDAL 3.6.1** version. Each runtime has to be build separately, but this can be done concurrently as they are using different contexts (build folders). Primary operating bindings (in gdal.core package) are build from **windows**.
 
-To make everything work smoothly, each configuration targets same drivers and their versions respectively.
+To make everything work smoothly, each configuration targets the same drivers and their versions, respectively.
 
 To start building for a specific runtime, see the **README.md** in a respective directory.
 
 ## FAQ
 
-#### Q: Packages do not work on CentOS 7, Ubuntu 18.04
-A: It's an old distro and is out of support (EOL). Use docker (see [this Dockerfile](tests/MaxRev.Gdal.Core.Tests/Dockerfile) how to package your app) or a newer distro (GLIBC 2.31+). Packages for older systems are difficult to maintain. From 3.6.x version the Debian 11 distro is used. See [this](https://github.com/MaxRev-Dev/gdal.netcore/issues/87#issuecomment-1377995387) for more info.
+#### Q: Packages does not work on CentOS 7, Ubuntu 18.04
+A: These are old distros and are out of support (EOL). Use docker (see [this Dockerfile](tests/MaxRev.Gdal.Core.Tests/Dockerfile) how to package your app) or a newer distro (GLIBC 2.31+). Packages for older systems are difficult to maintain. From 3.6.x version the Debian 11 distro is used. See [this](https://github.com/MaxRev-Dev/gdal.netcore/issues/87#issuecomment-1377995387) for more info.
 
 #### Q: Projections are not working as expected
 A: This package only contains the [`proj.db` database](https://proj.org/resource_files.html#proj-db). Make sure you have installed `proj-data` package. It contains aditional grid shifts and other data required for projections. Add path to your data folder with `MaxRev.Gdal.Core.Proj.Configure()`. See [this](https://proj.org/resource_files.html) for more info.
@@ -125,7 +125,7 @@ A: Feel free to contribute and I will help you you to add them. Here's the my ad
 
 #### Q: GDAL functions are not working as expected
 
-A: Try to search an [issue on github](https://github.com/OSGeo/gdal/issues). In 98% cases, I'm sure they are working fine.  
+A: Try to search an [issue on github](https://github.com/OSGeo/gdal/issues). In 98% of cases, they are working fine.
 
 #### Q: Some types throw exceptions from SWIG on Windows
 
@@ -133,7 +133,7 @@ A: Yes, currently there are [some redundant](https://github.com/MaxRev-Dev/gdal.
 
 #### Q: Can I compile it on Ubuntu or another Unix-based system?
 
-A: From the 3.6.x version the Debian 11 distro is used. Prior to 3.6.x version packages were built on CentOS - glibc of version 2.17. It's the lowest version [(in my opinion)](https://github.com/MaxRev-Dev/gdal.netcore/issues/1#issuecomment-522817778) that suits for all common systems (Ubuntu, Debian, Fedora)
+A: From the 3.6.x version the Debian 11 distro is used. Prior to 3.6.x version packages were built on CentOS - glibc of version 2.17. It's the lowest version [(in my opinion)](https://github.com/MaxRev-Dev/gdal.netcore/issues/1#issuecomment-522817778) that suits all common systems (Ubuntu, Debian, Fedora).
 
 #### Q: In some methods performance is slower on Unix 
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ NuGet: [MaxRev.Gdal.WindowsRuntime.Minimal](https://www.nuget.org/packages/MaxRe
   * [Building runtime libraries](#building-runtime-libraries)
   * [FAQ](#faq)
       - [Q: Packages do not work on CentOS 7, Ubuntu 18.04](#q-packages-does-not-work-on-centos-7-ubuntu-1804)
+      - [Q: Can I compile it on Ubuntu or another Unix-based system?](#q-can-i-compile-it-on-ubuntu-or-another-unix-based-system-)
       - [Q: Projections are not working as expected](#q-projections-are-not-working-as-expected)
       - [Q: Some drivers complain about missing data files](#q-some-drivers-complain-about-missing-data-files)
       - [Q: Missing {some} drivers, can you add more?](#q-missing--some--drivers--can-you-add-more-)
       - [Q: GDAL functions are not working as expected](#q-gdal-functions-are-not-working-as-expected)
       - [Q: Some types throw exceptions from SWIG on Windows](#q-some-types-throw-exceptions-from-swig-on-windows)
-      - [Q: Can I compile it on Ubuntu or another Unix-based system?](#q-can-i-compile-it-on-ubuntu-or-another-unix-based-system-)
       - [Q: In some methods performance is slower on Unix](#q-in-some-methods-performance-is-slower-on-unix)
       - [Q: OSGeo.OGR.SpatialReference throws System.EntryPointNotFoundException exception](#q-osgeoogrspatialreference-throws-systementrypointnotfoundexception-exception)
   * [About and Contacts](#about-and-contacts)
@@ -113,6 +113,10 @@ To start building for a specific runtime, see the **README.md** in a respective 
 #### Q: Packages does not work on CentOS 7, Ubuntu 18.04
 A: These are old distros and are out of support (EOL). Use docker (see [this Dockerfile](tests/MaxRev.Gdal.Core.Tests/Dockerfile) how to package your app) or a newer distro (GLIBC 2.31+). Packages for older systems are difficult to maintain. From 3.6.x version the Debian 11 distro is used. See [this](https://github.com/MaxRev-Dev/gdal.netcore/issues/87#issuecomment-1377995387) for more info.
 
+#### Q: Can I compile it on Ubuntu or another Unix-based system?
+
+A: Yes, you can (see [unix](/unix/) folder for readme). All you have to do, is to choose one of the latest distros like Ubuntu 22.04 or Debian 11 (recommended). From the 3.6.x version the Debian 11 distro is used by default. It was changed because of EOL of the previous distro (see answer above). Prior to 3.6.x version packages were built on CentOS - glibc of version 2.17. It's the lowest version [(in my opinion)](https://github.com/MaxRev-Dev/gdal.netcore/issues/1#issuecomment-522817778) that suits all common systems (Ubuntu, Debian, Fedora).
+
 #### Q: Projections are not working as expected
 A: This package only contains the [`proj.db` database](https://proj.org/resource_files.html#proj-db). Make sure you have installed `proj-data` package. It contains aditional grid shifts and other data required for projections. Add path to your data folder with `MaxRev.Gdal.Core.Proj.Configure()`. See [this](https://proj.org/resource_files.html) for more info.
 
@@ -130,10 +134,6 @@ A: Try to search an [issue on github](https://github.com/OSGeo/gdal/issues). In 
 #### Q: Some types throw exceptions from SWIG on Windows
 
 A: Yes, currently there are [some redundant](https://github.com/MaxRev-Dev/gdal.netcore/issues/11) types in OGR namespace. This will be fixed in the next builds.
-
-#### Q: Can I compile it on Ubuntu or another Unix-based system?
-
-A: From the 3.6.x version the Debian 11 distro is used. Prior to 3.6.x version packages were built on CentOS - glibc of version 2.17. It's the lowest version [(in my opinion)](https://github.com/MaxRev-Dev/gdal.netcore/issues/1#issuecomment-522817778) that suits all common systems (Ubuntu, Debian, Fedora).
 
 #### Q: In some methods performance is slower on Unix 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gdal.netcore [![Mentioned in Awesome Geospatial](https://awesome.re/mentioned-badge.svg)](https://github.com/sacridini/Awesome-Geospatial) ![Packages CI](https://github.com/MaxRev-Dev/gdal.netcore/workflows/CI/badge.svg?branch=master)
 
-A simple (as is) build engine of [GDAL](https://gdal.org/) 3.6.0 library for [.NET](https://dotnet.microsoft.com/download). 
+A simple (as is) build engine of [GDAL](https://gdal.org/) 3.6.1 library for [.NET](https://dotnet.microsoft.com/download). 
 
 ## Packages
 
@@ -24,6 +24,9 @@ NuGet: [MaxRev.Gdal.WindowsRuntime.Minimal](https://www.nuget.org/packages/MaxRe
   * [About build configuration](#about-build-configuration)
   * [Building runtime libraries](#building-runtime-libraries)
   * [FAQ](#faq)
+      - [Q: Packages do not work on CentOS 7, Ubuntu 18.04](#q-packages-do-not-work-on-centos-7-ubuntu-1804)
+      - [Q: Projections are not working as expected](#q-projections-are-not-working-as-expected)
+      - [Q: Some drivers complain about missing data files](#q-some-drivers-complain-about-missing-data-files)
       - [Q: Missing {some} drivers, can you add more?](#q-missing--some--drivers--can-you-add-more-)
       - [Q: GDAL functions are not working as expected](#q-gdal-functions-are-not-working-as-expected)
       - [Q: Some types throw exceptions from SWIG on Windows](#q-some-types-throw-exceptions-from-swig-on-windows)
@@ -40,7 +43,7 @@ NuGet: [MaxRev.Gdal.WindowsRuntime.Minimal](https://www.nuget.org/packages/MaxRe
 
 - Only generates assemblies and binds everything into one package.
 - Provides easy access to GDAL by installing **only core and runtime package**
-- DOES NOT require installation of GDAL 
+- DOES NOT require installation of GDAL. From 3.6.1 version GDAL_DATA is also shipped. While it contains the `proj.db` database you can require `proj-data` grid shifts.
 
 ### What is not
 
@@ -90,22 +93,31 @@ Detailed guide is here - [unix](unix/).
 
 ## About build configuration
 
-Current version targets **GDAL 3.6.0** with **minimal drivers**. What stands for 'minimal' - drivers that require no additional dependencies (mainly boost). For example, `MySQL` driver is not included, because it requires 15+ boost deps. Same goes for `Poppler` driver. They will be included upon request.
+Current version targets **GDAL 3.6.1** with **minimal drivers**. What stands for 'minimal' - drivers that require no additional dependencies (mainly boost). For example, `MySQL` driver is not included, because it requires 15+ boost deps. Same goes for `Poppler` driver. They can be packaged upon a request.
 
 Drivers included PROJ(7.2.1), GEOS(3.11.1) and more than 200 other drivers.
-To view full list of drivers, see property `DriversInCurrentVersion` [here](tests/MaxRev.Gdal.Core.Tests.XUnit/CommonTests.cs).
+To view full list of drivers, run view the full list of drivers with GDAL's API or see property `DriversInCurrentVersion` [here](tests/MaxRev.Gdal.Core.Tests.XUnit/CommonTests.cs).
 
-**NOTE**: Windows and Linux drivers availability may differ, ask me of specific driver for runtime. Please issue, if I forgot to mention any other packages.
+**NOTE**: Windows and Linux drivers availability may differ, ask me of a specific driver for runtime. Please issue, if I forgot to mention any packages.
 
 ## Building runtime libraries
 
-Current version is targeting **GDAL 3.6.0** version. Each runtime has to be build separately, but this can be done concurrently as they are using different contexts (build folders). Main operating bindings (in gdal.core package) are build from **windows**.
+Current version is targeting **GDAL 3.6.1** version. Each runtime has to be build separately, but this can be done concurrently as they are using different contexts (build folders). Main operating bindings (in gdal.core package) are build from **windows**.
 
 To make everything work smoothly, each configuration targets same drivers and their versions respectively.
 
 To start building for a specific runtime, see the **README.md** in a respective directory.
 
 ## FAQ
+
+#### Q: Packages do not work on CentOS 7, Ubuntu 18.04
+A: It's an old distro and is out of support (EOL). Use docker (see [this Dockerfile](tests/MaxRev.Gdal.Core.Tests/Dockerfile) how to package your app) or a newer distro (GLIBC 2.31+). Packages for older systems are difficult to maintain. From 3.6.x version the Debian 11 distro is used. See [this](https://github.com/MaxRev-Dev/gdal.netcore/issues/87#issuecomment-1377995387) for more info.
+
+#### Q: Projections are not working as expected
+A: This package only contains the [`proj.db` database](https://proj.org/resource_files.html#proj-db). Make sure you have installed `proj-data` package. It contains aditional grid shifts and other data required for projections. Add path to your data folder with `MaxRev.Gdal.Core.Proj.Configure()`. See [this](https://proj.org/resource_files.html) for more info.
+
+#### Q: Some drivers complain about missing data files
+A: This is related to the previous package versions (prior to 3.6.1). From 3.6.1 version, `GDAL_DATA` folder is also shipped with core package.
 
 #### Q: Missing {some} drivers, can you add more?
 
@@ -121,11 +133,11 @@ A: Yes, currently there are [some redundant](https://github.com/MaxRev-Dev/gdal.
 
 #### Q: Can I compile it on Ubuntu or another Unix-based system?
 
-A: The main reason I'm compiling it on CentOS - glibc of version 2.17. It's the lowest version [(in my opinion)](https://github.com/MaxRev-Dev/gdal.netcore/issues/1#issuecomment-522817778) that suits for all common systems (Ubuntu, Debian, Fedora)
+A: From the 3.6.x version the Debian 11 distro is used. Prior to 3.6.x version packages were built on CentOS - glibc of version 2.17. It's the lowest version [(in my opinion)](https://github.com/MaxRev-Dev/gdal.netcore/issues/1#issuecomment-522817778) that suits for all common systems (Ubuntu, Debian, Fedora)
 
 #### Q: In some methods performance is slower on Unix 
 
-A: Use of [older version](https://github.com/MaxRev-Dev/gdal.netcore/issues/1) of GLIBC might be [a reason](https://github.com/MaxRev-Dev/gdal.netcore/issues/6). But It's not a fault of build engine.
+A: Apparently, it's not a fault of the build engine. I did not face this issue and I use this packages in several production environments.
 
 #### Q: OSGeo.OGR.SpatialReference throws System.EntryPointNotFoundException exception
 

--- a/compile/GdalBaseExtensions.cs
+++ b/compile/GdalBaseExtensions.cs
@@ -8,12 +8,12 @@ namespace MaxRev.Gdal.Core
 {
     internal static class GdalBaseExtensions
     {
-        public static string GetSourceLocation(this Assembly asm)
+        internal static string GetSourceLocation(this Assembly asm)
         {
             return !string.IsNullOrEmpty(asm.Location) ? asm.Location : AppContext.BaseDirectory;
         }
 
-        public static string GetEnvRID()
+        internal static string GetEnvRID()
         {
             return Environment.OSVersion.Platform switch
             {
@@ -21,6 +21,44 @@ namespace MaxRev.Gdal.Core
                 PlatformID.Win32NT => "win-x64",
                 _ => throw new PlatformNotSupportedException(),
             };
+        } 
+        
+        internal static IEnumerable<string> GetPackageDataPossibleLocations(string runtimesPath, string libsharedFolder)
+        {
+            var entryAsm = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
+            // assembly location can be empty with bundled assemblies
+            var entryRoot =
+                new FileInfo(entryAsm.GetSourceLocation())
+                    .Directory!.FullName;
+
+            var executingRoot =
+                new FileInfo(Assembly.GetExecutingAssembly().GetSourceLocation())
+                    .Directory!.FullName;
+
+            // this list is sorted according to expected 
+            // contents location related to
+            // published binaries location
+            return new[]
+            {
+                // test runner use this and docker containers
+                Path.Combine(executingRoot, runtimesPath, libsharedFolder),
+                Path.Combine(executingRoot, libsharedFolder),
+                // self-contained published package 
+                // with custom working directory
+                Path.Combine(entryRoot, runtimesPath, libsharedFolder),
+                Path.Combine(entryRoot, libsharedFolder),
+
+                // azure functions
+                Path.Combine(executingRoot, "..", runtimesPath, libsharedFolder),
+
+                // These cases are last hope solutions: 
+                // some environments may have flat structure
+                // let's try to search in root directories
+                entryRoot,
+                executingRoot,
+                runtimesPath,
+                libsharedFolder,
+            }.Select(x => new DirectoryInfo(x).FullName);
         }
     }
 }

--- a/compile/GdalConfigureAll.cs
+++ b/compile/GdalConfigureAll.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
+
+#nullable enable
 
 namespace MaxRev.Gdal.Core
 {
@@ -20,16 +18,33 @@ namespace MaxRev.Gdal.Core
         /// <summary>
         /// Performs search for gdalplugins and calls 
         /// <see cref="OSGeo.GDAL.Gdal.AllRegister"/> and <see cref="OSGeo.OGR.Ogr.RegisterAll"/>
+        /// <param name="gdalDataFolder">path to set as GDAL_DATA option</param>
         /// </summary>
-        public static void ConfigureGdalDrivers()
+        public static void ConfigureGdalDrivers(string? gdalDataFolder = null)
         {
             if (IsConfigured) return;
 
             OSGeo.GDAL.Gdal.AllRegister();
             OSGeo.OGR.Ogr.RegisterAll();
 
+            ConfigureGdalData(gdalDataFolder);
             // set flag only on success
             IsConfigured = true;
+        }
+
+        /// <summary>
+        /// Set path for GDAL_DATA option.
+        /// </summary>
+        /// <param name="gdalDataFolder"></param>
+        public static void ConfigureGdalData(string? gdalDataFolder = null)
+        {
+            if (gdalDataFolder is null)
+            {
+                var runtimes = $"runtimes/any-x64/native";
+                var helperLocations = GdalBaseExtensions.GetPackageDataPossibleLocations(runtimes, "gdal-data");
+                gdalDataFolder = helperLocations.FirstOrDefault(Directory.Exists);
+            }
+            OSGeo.GDAL.Gdal.SetConfigOption("GDAL_DATA", gdalDataFolder);
         }
 
         /// <summary>

--- a/compile/ProjConfigure.cs
+++ b/compile/ProjConfigure.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.IO;
 using System.Reflection;
@@ -11,19 +12,20 @@ namespace MaxRev.Gdal.Core
     public static class Proj
     {
         /// <summary>
-        /// Performs search for proj.db in project directories and sets search paths for Proj. 
+        /// Performs search for proj.db in project directories and sets search paths for Proj. <br/>
+        /// If the proj.db exists in user directory, it will be used. Otherwise, the first found proj.db will be used.
+        /// <para>
+        /// Search order: <br/>
+        /// - User defined paths <br/>
+        /// - Executable directory (current working directory) <br/>
+        /// - Entry assembly directory  
+        /// - runtimes/&lt;platform&gt;/native/ directory
+        /// </para> 
         /// You can call <see cref="OSGeo.OSR.Osr.SetPROJSearchPaths"/> alternatively.
         /// </summary>
         /// <param name="additionalSearchPaths">optional additional paths</param> 
         public static void Configure(params string[] additionalSearchPaths)
         {
-            // fast set and forget if user provides a custom location
-            if (additionalSearchPaths.Any())
-            {
-                OSGeo.OSR.Osr.SetPROJSearchPaths(additionalSearchPaths);
-                return;
-            }
-
             const string libshared = "maxrev.gdal.core.libshared";
             var runtimes = $"runtimes/{GdalBaseExtensions.GetEnvRID()}/native";
             var entryAsm = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
@@ -42,7 +44,7 @@ namespace MaxRev.Gdal.Core
                 // this list is sorted according to expected 
                 // contents location related to
                 // published binaries location
-                var possibleLocations = new[]
+                var possibleLocations = additionalSearchPaths.Concat(new[]
                 {
                     // test runner use this and docker containers
                     Path.Combine(executingRoot, runtimes, libshared),
@@ -55,37 +57,39 @@ namespace MaxRev.Gdal.Core
                     // azure functions
                     Path.Combine(executingRoot, "..", runtimes, libshared),
 
-                    // These cases are last hope solututions: 
+                    // These cases are last hope solutions: 
                     // some environments may have flat structure
                     // let's try to search in root directories
                     entryRoot,
                     executingRoot,
                     runtimes,
                     libshared,
-                }.Select(x => new DirectoryInfo(x).FullName);
+                }).Select(x => new DirectoryInfo(x).FullName).ToArray();
 
-                string found = "";
+                string? found = default;
 
                 foreach (var item in possibleLocations)
                 {
                     if (!Directory.Exists(item))
                         continue;
                     var search = Directory.EnumerateFiles(item, "proj.db");
-                    if (search.Any())
-                    {
-                        found = item;
-                        break;
-                    }
+                    if (!search.Any())
+                        continue;
+                    found = item;
+                    break;
                 }
 
-                if (found != "")
+                if (found is null)
                 {
-                    OSGeo.OSR.Osr.SetPROJSearchPaths(new[] { found });
-                    return;
+                    // we did not find anything
+                    throw new FileNotFoundException(
+                        $"Can not find proj.db. Tried to search in {string.Join(", ", possibleLocations)}");
                 }
 
-                // we did not found anything
-                throw new FileNotFoundException($"Can't find proj.db. Tried to search in {string.Join(", ", possibleLocations)}");
+                // as we search in the user defined paths first 
+                // there will be always proj.db from a user defined path 
+                // other proj grid files will be searched in additional directories
+                OSGeo.OSR.Osr.SetPROJSearchPaths(new[] { found }.Concat(additionalSearchPaths).Distinct().ToArray());
             }
             catch (Exception ex) when (ex is not FileNotFoundException)
             {

--- a/gdalcore.loader.csproj
+++ b/gdalcore.loader.csproj
@@ -9,12 +9,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>MaxRev.Gdal.Core</PackageId>
     <AssemblyName>MaxRev.Gdal.Core</AssemblyName>
+    <RootNamespace>MaxRev.Gdal.Core</RootNamespace>
     <PackageTags>gdal;netcore;docker</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <LangVersion>10.0</LangVersion>
     <RepositoryUrl>https://github.com/MaxRev-Dev/gdal.netcore</RepositoryUrl>
-    <Version>3.6.1.100</Version>
+    <Version>3.6.1.110</Version>
     <Description>
       GDAL (3.6.1) bindings for dotnet core (now linux-x64 and win-x64).
       Bridge between gdal and netcore.
@@ -22,7 +23,6 @@
       Works in docker containers without pkg installations!!
       Just call - GdalBase.ConfigureAll()
     </Description>
-    <RootNamespace></RootNamespace>
     <PackageReleaseNotes>
       - GDAL Version 3.6.1
       - built with VCPKG

--- a/gdalcore.loader.csproj
+++ b/gdalcore.loader.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <LangVersion>10.0</LangVersion>
     <RepositoryUrl>https://github.com/MaxRev-Dev/gdal.netcore</RepositoryUrl>
-    <Version>3.6.1.110</Version>
+    <Version>3.6.1.120</Version>
     <Description>
       GDAL (3.6.1) bindings for dotnet core (now linux-x64 and win-x64).
       Bridge between gdal and netcore.
@@ -25,7 +25,8 @@
     </Description>
     <PackageReleaseNotes>
       - GDAL Version 3.6.1
-      - built with VCPKG
+      - Built with VCPKG
+      - Automatically set GDAL_DATA option on startup
     </PackageReleaseNotes>
   </PropertyGroup>
 
@@ -54,6 +55,13 @@
     <Compile Remove="build-unix/**" />
     <EmbeddedResource Remove="tests/**" />
     <Compile Include="compile/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build-win/gdal-build/share/gdal/**">
+      <PackagePath>runtimes/any-x64/native/gdal-data/</PackagePath>
+      <Pack>true</Pack>
+    </None>
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Unix' AND '$(Platform)'=='x64'">

--- a/tests/MaxRev.Gdal.Core.Tests.AzureFunctions/ConfigureFunction.cs
+++ b/tests/MaxRev.Gdal.Core.Tests.AzureFunctions/ConfigureFunction.cs
@@ -1,19 +1,14 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
 
 namespace MaxRev.Gdal.Core.Tests.AzureFunctions
 {
     public static class ConfigureFunction
     {
-        static ConfigureFunction()
-        {
-            GdalBase.ConfigureAll();
-        }
-
         [FunctionName("ConfigureFunction")]
         public static Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
@@ -31,6 +26,7 @@ namespace MaxRev.Gdal.Core.Tests.AzureFunctions
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
             ILogger log)
         {
+            GdalBase.ConfigureAll();
             return GdalBase.IsConfigured;
         }
     }

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/FunctionsTests.cs
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/FunctionsTests.cs
@@ -1,4 +1,4 @@
-﻿using GdalCore_AzureFunctions;
+﻿using MaxRev.Gdal.Core.Tests.AzureFunctions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
@@ -8,7 +8,7 @@
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.100" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.110" />
     <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.6.1.100" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.1.110" /> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
@@ -8,7 +8,7 @@
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.110" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.120" />
     <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.6.1.100" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.1.110" /> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/ProjTests.cs
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/ProjTests.cs
@@ -1,5 +1,5 @@
 using MaxRev.Gdal.Core;
-using OSGeo.OSR; 
+using OSGeo.OSR;
 using Xunit;
 
 namespace GdalCore_XUnit

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/utf8-data/test1.vrt
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/utf8-data/test1.vrt
@@ -4,30 +4,9 @@
   <VRTRasterBand dataType="Byte" band="1">
     <ColorInterp>Gray</ColorInterp>
     <SimpleSource>
-      <SourceFilename relativeToVRT="1">тест.tif</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="514" BlockYSize="15" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
       <SourceFilename relativeToVRT="1">input.tif</SourceFilename>
       <SourceBand>1</SourceBand>
       <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="514" BlockYSize="15" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
-      <SourceFilename relativeToVRT="1">test2.vrt</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
-      <SourceFilename relativeToVRT="1">test4.vrt</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
       <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
     </SimpleSource>
@@ -39,7 +18,21 @@
       <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
     </SimpleSource>
     <SimpleSource>
+      <SourceFilename relativeToVRT="1">test2.vrt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
+      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
+      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
+    </SimpleSource>
+    <SimpleSource>
       <SourceFilename relativeToVRT="1">test3.vrt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
+      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
+      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">test4.vrt</SourceFilename>
       <SourceBand>1</SourceBand>
       <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/utf8-data/test2.vrt
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/utf8-data/test2.vrt
@@ -4,30 +4,9 @@
   <VRTRasterBand dataType="Byte" band="1">
     <ColorInterp>Gray</ColorInterp>
     <SimpleSource>
-      <SourceFilename relativeToVRT="1">тест.tif</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="514" BlockYSize="15" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
       <SourceFilename relativeToVRT="1">input.tif</SourceFilename>
       <SourceBand>1</SourceBand>
       <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="514" BlockYSize="15" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
-      <SourceFilename relativeToVRT="1">test2.vrt</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
-      <SourceFilename relativeToVRT="1">test4.vrt</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
       <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
     </SimpleSource>
@@ -39,7 +18,21 @@
       <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
     </SimpleSource>
     <SimpleSource>
+      <SourceFilename relativeToVRT="1">test2.vrt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
+      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
+      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
+    </SimpleSource>
+    <SimpleSource>
       <SourceFilename relativeToVRT="1">test3.vrt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
+      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
+      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">test4.vrt</SourceFilename>
       <SourceBand>1</SourceBand>
       <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/utf8-data/test3.vrt
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/utf8-data/test3.vrt
@@ -4,30 +4,9 @@
   <VRTRasterBand dataType="Byte" band="1">
     <ColorInterp>Gray</ColorInterp>
     <SimpleSource>
-      <SourceFilename relativeToVRT="1">тест.tif</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="514" BlockYSize="15" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
       <SourceFilename relativeToVRT="1">input.tif</SourceFilename>
       <SourceBand>1</SourceBand>
       <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="514" BlockYSize="15" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
-      <SourceFilename relativeToVRT="1">test2.vrt</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
-      <SourceFilename relativeToVRT="1">test4.vrt</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
       <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
     </SimpleSource>
@@ -39,7 +18,21 @@
       <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
     </SimpleSource>
     <SimpleSource>
+      <SourceFilename relativeToVRT="1">test2.vrt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
+      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
+      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
+    </SimpleSource>
+    <SimpleSource>
       <SourceFilename relativeToVRT="1">test3.vrt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
+      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
+      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">test4.vrt</SourceFilename>
       <SourceBand>1</SourceBand>
       <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/utf8-data/test4.vrt
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/utf8-data/test4.vrt
@@ -4,30 +4,9 @@
   <VRTRasterBand dataType="Byte" band="1">
     <ColorInterp>Gray</ColorInterp>
     <SimpleSource>
-      <SourceFilename relativeToVRT="1">тест.tif</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="514" BlockYSize="15" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
       <SourceFilename relativeToVRT="1">input.tif</SourceFilename>
       <SourceBand>1</SourceBand>
       <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="514" BlockYSize="15" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
-      <SourceFilename relativeToVRT="1">test2.vrt</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
-      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
-      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
-    </SimpleSource>
-    <SimpleSource>
-      <SourceFilename relativeToVRT="1">test4.vrt</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
       <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
     </SimpleSource>
@@ -39,7 +18,21 @@
       <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
     </SimpleSource>
     <SimpleSource>
+      <SourceFilename relativeToVRT="1">test2.vrt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
+      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
+      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
+    </SimpleSource>
+    <SimpleSource>
       <SourceFilename relativeToVRT="1">test3.vrt</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
+      <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />
+      <DstRect xOff="0" yOff="0" xSize="514" ySize="515" />
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">test4.vrt</SourceFilename>
       <SourceBand>1</SourceBand>
       <SourceProperties RasterXSize="514" RasterYSize="515" DataType="Byte" BlockXSize="128" BlockYSize="128" />
       <SrcRect xOff="0" yOff="0" xSize="514" ySize="515" />

--- a/tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj
@@ -9,9 +9,9 @@
     <RootNamespace>MaxRev.Gdal.Core.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.100" />
+    <PackageReference Include="MaxRev.Gdal.Core" Version="3.6.1.110" />
     <PackageReference Include="MaxRev.Gdal.LinuxRuntime.Minimal" Version="3.6.1.100" />
-    <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.1.100" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
+    <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.6.1.110" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
   </ItemGroup>
 </Project>

--- a/tests/MaxRev.Gdal.Core.Tests/Program.cs
+++ b/tests/MaxRev.Gdal.Core.Tests/Program.cs
@@ -5,6 +5,7 @@ using OSGeo.OSR;
 using System;
 using System.IO;
 using System.Reflection;
+using OSGeo.OGR;
 
 namespace GdalCoreTest
 {
@@ -19,6 +20,11 @@ namespace GdalCoreTest
                 GdalBase.ConfigureAll();
                 GdalBase.ConfigureAll();
                 Console.WriteLine("GDAL configured");
+                Console.WriteLine("OGR Vector Drivers: {0}", Ogr.GetDriverCount());
+                var rasterCount = Enumerable
+                    .Range(0, Gdal.GetDriverCount()).Select(Gdal.GetDriver)
+                    .Count(x => x.GetMetadataItem("DCAP_RASTER", null) == "YES");
+                Console.WriteLine("GDAL Raster Drivers: {0}", rasterCount);
 
                 var version = Assembly.GetAssembly(typeof(MaxRev.Gdal.Core.GdalBase))
                          .GetCustomAttribute<AssemblyInformationalVersionAttribute>()

--- a/unix/README.md
+++ b/unix/README.md
@@ -1,5 +1,14 @@
 # Building GDAL bindings on unix
 
+  * [Prerequisites](#prerequisites)
+    + [**1. Environment**](#1-environment)
+    + [**2. Base packages**](#2-base-packages-vcpkg-and-pipeline-scripts-won-t-work-without-them)
+    + [3. **Install .NET**](#3-install-net)
+    + [4. **Installing libraries**.](#4-installing-libraries)
+      - [Optional libraries](#optional-libraries)
+    + [5. **Compiling**](#5-compiling)
+    + [6. **How to check dependencies:**](#6-how-to-check-dependencies)
+
 ## Prerequisites
 
 First of all, I wish you to be patient & bring your snacks. Compilation from scratch takes nearly for 1 hour. But from version 3.6 it possibly faster with CMake.

--- a/win/README.md
+++ b/win/README.md
@@ -3,8 +3,9 @@
 ## Table of contents
 
 - [Windows build scripts for GDAL](#windows-build-scripts-for-gdal)
-  * [Prerequisites:](#prerequisites-)
-  * [Building: (in PowerShell)](#building---in-powershell-)
+  * [Prerequisites:](#prerequisites)
+  * [Building: (in PowerShell)](#building-in-powershell)
+  * [Troubleshooting dependencies:](#troubleshooting-dependencies)
 
 Table of contents generated with [markdown-toc](http://ecotrust-canada.github.io/markdown-toc/).
 


### PR DESCRIPTION
 Changes:
  - From the 3.6.x version, the Debian 11 distro is used. Mention this in the docs.
  - Allow specifying additional grid shifts folder.
  - The same algorithm used to find `proj.db`  is used to search for `gdal-data` folder from the package in different environments.
 
 closes #91, closes #87 
