### PR TITLE
Hotfix: Runtime bundles should include only native binaries

### DIFF
--- a/unix/publish-makefile
+++ b/unix/publish-makefile
@@ -34,9 +34,6 @@ update-targets:
 	cd $(PACKAGE_BUILD_ROOT) && \
 		dotnet add $(RUNTIME_PROJECT_BUNDLE_$(CAT_NAME_UP)_FINAL) package MaxRev.Gdal.$(RUNTIME_PACKAGE_PARTIAL).Minimal$(BUILD_ARCH_SUFFIX) \
 			--no-restore -v "$(GDAL_VERSION).$(PACKAGE_BUILD_NUMBER)" -s $(NUGET_)
-	cd $(PACKAGE_BUILD_ROOT) && \
-		dotnet add $(RUNTIME_PROJECT_BUNDLE_$(CAT_NAME_UP)_FINAL) package MaxRev.Gdal.Core \
-			--no-restore -v "$(GDAL_VERSION).$(PACKAGE_BUILD_NUMBER)" -s $(NUGET_)
 
 pack-core: generate-projects
 	dotnet pack -c Release -o $(NUGET_) $(GDALCORE_PROJECT_FINAL)


### PR DESCRIPTION
**Non-breaking changes:**
By default, runtime packages (bundles) should not contain the core packages. For this purpose, we have introduced the Universal package.
The reference was added inadvertently during the refactoring. This can cause collisions if the core and runtime versions are different, but it's still recommended to use identical versions of bindings. The following changes will restore the old behaviour and remove the core package reference from osx/unix bundles.