### PR TITLE
Hotfix: CRT runtime dependencies

### DIFF
--- a/osx/test-makefile
+++ b/osx/test-makefile
@@ -10,7 +10,7 @@ TEST_TARGET=$(TEST_DIR_APP)
 CMD_TYPE=dotnet run
 endif
 
-MISSING_PACKAGES=MaxRev.Gdal.LinuxRuntime.Minimal MaxRev.Gdal.WindowsRuntime.Minimal
+MISSING_PACKAGES=MaxRev.Gdal.LinuxRuntime.Minimal MaxRev.Gdal.WindowsRuntime.Minimal MaxRev.Gdal.Universal
 
 any: test
 
@@ -20,13 +20,13 @@ test-restore:
 		cd "$(TEST_DIR)/../MaxRev.Gdal.Core.Tests.AzureFunctions" && dotnet remove package $$v &> /dev/null; \
 		cd "$(TEST_DIR)/../MaxRev.Gdal.Core.Tests" && dotnet remove package $$v &> /dev/null;  \
 	done;
-	cd $(TEST_TARGET) && \
+	-cd $(TEST_TARGET) && \
 		dotnet restore --ignore-failed-sources
 
 test-update:
-	cd $(TEST_TARGET) && \
+	-cd $(TEST_TARGET) && \
 		dotnet add package MaxRev.Gdal.MacosRuntime.Minimal.$(BUILD_ARCH) --no-restore -v "$(GDAL_VERSION).$(PACKAGE_BUILD_NUMBER_OSX)" -s $(NUGET_)
-	cd $(TEST_TARGET) && \
+	-cd $(TEST_TARGET) && \
 		dotnet add package MaxRev.Gdal.Core  --no-restore -v "$(GDAL_VERSION).$(PACKAGE_BUILD_NUMBER_OSX)" -s $(NUGET_)
 
 test-only: test-restore

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Core" Version="3.9.0.*" />
+    <PackageReference Include="MaxRev.Gdal.Universal" Version="3.9.1.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/unix/test-makefile
+++ b/unix/test-makefile
@@ -10,19 +10,23 @@ TEST_TARGET=$(TEST_DIR_APP)
 CMD_TYPE=dotnet run
 endif
 
-MISSING_PACKAGES=MaxRev.Gdal.MacosRuntime.Minimal MaxRev.Gdal.WindowsRuntime.Minimal
+MISSING_PACKAGES=MaxRev.Gdal.MacosRuntime.Minimal MaxRev.Gdal.WindowsRuntime.Minimal MaxRev.Gdal.Universal
 
 all: test
 
 ###	Testing linux libraries (from nuget build output)
 test-restore:
-	cd $(TEST_TARGET) && \
+	-@for v in $(MISSING_PACKAGES); do \
+		cd "$(TEST_DIR)/../MaxRev.Gdal.Core.Tests.AzureFunctions" && dotnet remove package $$v &> /dev/null; \
+		cd "$(TEST_DIR)/../MaxRev.Gdal.Core.Tests" && dotnet remove package $$v &> /dev/null;  \
+	done;
+	-cd $(TEST_TARGET) && \
 		dotnet restore --ignore-failed-sources
 
 test-update:
-	cd $(TEST_TARGET) && \
+	-cd $(TEST_TARGET) && \
 		dotnet add package MaxRev.Gdal.LinuxRuntime.Minimal.$(BUILD_ARCH) -v "$(GDAL_VERSION).$(PACKAGE_BUILD_NUMBER)" -s $(NUGET_)
-	cd $(TEST_TARGET) && \
+	-cd $(TEST_TARGET) && \
 		dotnet add package MaxRev.Gdal.Core -v "$(GDAL_VERSION).$(PACKAGE_BUILD_NUMBER)" -s $(NUGET_)
 
 test-only: test-restore

--- a/win/collect-deps-makefile.vc
+++ b/win/collect-deps-makefile.vc
@@ -37,6 +37,6 @@ collect: collect_bindings copyprojdb
 # 	remove SDK dlls that are not needed
 	$(DEL_FILE) "$(OUTPUT)\gdal*.dll"
 	$(COPY) "$(abspath $(BUILD_ROOT)\gdal-build\share\csharp)\*_wrap.dll" "$(OUTPUT)\"
-	$(COPY_I) "%VCToolsRedistDir%x64\Microsoft.VC$(CRT_VERSION).CRT\*.dll" "$(OUTPUT)\"
-	
 	for /d %i in ($(BUILD_ROOT)\*-build) do ( cd "%i" &  $(COPY) "%i\bin\*.dll" "$(OUTPUT)\" )
+	
+#	$(COPY_I) "%VCToolsRedistDir%x64\Microsoft.VC$(CRT_VERSION).CRT\*.dll" "$(OUTPUT)\"

--- a/win/partials.psm1
+++ b/win/partials.psm1
@@ -436,7 +436,7 @@ function Get-CollectDeps {
     $env:GDAL_DRIVER_PATH = "$env:GDAL_INSTALL_DIR\share\gdal"
     $env:PROJ_LIB = "$env:PROJ_INSTALL_DIR\share\proj"
 
-    $dllDirectories = @("$env:GDAL_INSTALL_DIR\bin", "$env:PROJ_INSTALL_DIR\bin", "$env:VCPKG_INSTALLED\bin", "$env:SDK_PREFIX\bin", $env:VCToolsRedistDir + "x64\")
+    $dllDirectories = @("$env:GDAL_INSTALL_DIR\bin", "$env:PROJ_INSTALL_DIR\bin", "$env:VCPKG_INSTALLED\bin", "$env:SDK_PREFIX\bin")
     Write-BuildInfo "Using DLL directories: $dllDirectories"
 
     Write-BuildInfo "Collecting dependent DLLs for $dllFile"

--- a/win/partials.psm1
+++ b/win/partials.psm1
@@ -436,7 +436,7 @@ function Get-CollectDeps {
     $env:GDAL_DRIVER_PATH = "$env:GDAL_INSTALL_DIR\share\gdal"
     $env:PROJ_LIB = "$env:PROJ_INSTALL_DIR\share\proj"
 
-    $dllDirectories = @("$env:GDAL_INSTALL_DIR\bin", "$env:PROJ_INSTALL_DIR\bin", "$env:VCPKG_INSTALLED\bin", "$env:SDK_PREFIX\bin")
+    $dllDirectories = @("$env:GDAL_INSTALL_DIR\bin", "$env:PROJ_INSTALL_DIR\bin", "$env:VCPKG_INSTALLED\bin", "$env:SDK_PREFIX\bin", $env:VCToolsRedistDir + "x64\")
     Write-BuildInfo "Using DLL directories: $dllDirectories"
 
     Write-BuildInfo "Collecting dependent DLLs for $dllFile"


### PR DESCRIPTION
Removing the hardcoded CRT version and switching the installed one on target machine.

Fixes #150 