### PR TITLE
GDAL v3.10.2

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -34,7 +34,7 @@ jobs:
             actions-runner: ubuntu-latest
           - os: linux/arm64
             arch: arm64
-            actions-runner: self-hosted-macos-arm64
+            actions-runner: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.actions-runner }}
     defaults:
@@ -158,7 +158,7 @@ jobs:
             actions-runner: ubuntu-latest
           - os: linux/arm64
             arch: arm64
-            actions-runner: self-hosted-macos-arm64
+            actions-runner: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.actions-runner }}
     defaults:

--- a/osx/README.md
+++ b/osx/README.md
@@ -14,7 +14,7 @@
 
 ### **1. Environment**
 There two types of builds **arm64** (Apple Silicon M1 & M2 chipsets) and **x86_64** (Intel chipsets). GH Actions runner is using a x64 3-core instances.
-This build was built using a self-hosted runner on a 10 CPU M2 Mac (arm64).
+This build was compiled using a `ubuntu-24.04-arm` runner (arm64).
  
 ### **2. Check for required libraries**
  **VPKG** will install all requirements defined in `shared/GdalCore.opt` file. Latest versions, no collisions with other dynamic libraries.

--- a/osx/gdal-makefile
+++ b/osx/gdal-makefile
@@ -82,6 +82,7 @@ HDF_zip=hdf$(HDF_VERSION).zip
 HDF_SOURCE=$(BUILD_ROOT)/hdf-$(HDF_VERSION)/hdfsrc
 
 download_hdf:
+	@echo "$(TO) Downloading HDF sources..."
 	curl -L -o "$(BUILD_ROOT)/$(HDF_zip)" "https://github.com/HDFGroup/hdf4/releases/download/hdf$(HDF_VERSION)/$(HDF_zip)"
 	cd "$(BUILD_ROOT)"; unzip -q "$(BUILD_ROOT)/$(HDF_zip)" -d "$(BUILD_ROOT)/hdf-$(HDF_VERSION)"
 
@@ -187,7 +188,7 @@ build_%:
 	@cd "$(BUILD_ROOT)/$(LW)-cmake-temp" && cmake --build . -j4 --target install || exit 1
 	@echo "$(TO) $(LW) was built successfully!"
 
-__DYLIBS_GDAL=DYLD_LIBRARY_PATH=$(DYLD_LIBRARY_PATH):$(BUILD_ROOT)/gdal-build/lib
+__DYLIBS_GDAL=DYLD_FALLBACK_LIBRARY_PATH=$(DYLD_FALLBACK_LIBRARY_PATH):$(BUILD_ROOT)/gdal-build/lib
 formats-output:
 	@mkdir -p $(TEST_FORMATS_OUTPUT)
 	@(cd $(BUILD_ROOT)/gdal-build/bin && $(__DYLIBS_GDAL) \
@@ -204,4 +205,4 @@ reset: reset_proj reset_gdal
 
 .EXPORT_ALL_VARIABLES:
 PKG_CONFIG_PATH=$(VCPKG_INSTALLED_DYNAMIC)/lib/pkgconfig
-DYLD_LIBRARY_PATH=$$DYLD_LIBRARY_PATH:${VCPKG_INSTALLED_DYNAMIC}/lib:${PROJ_BUILD}/lib:${HDF_BUILD}/lib
+DYLD_FALLBACK_LIBRARY_PATH=$$DYLD_FALLBACK_LIBRARY_PATH:${VCPKG_INSTALLED_DYNAMIC}/lib:${PROJ_BUILD}/lib:${HDF_BUILD}/lib

--- a/osx/gdal-makefile
+++ b/osx/gdal-makefile
@@ -85,6 +85,7 @@ download_hdf:
 	@echo "$(TO) Downloading HDF sources..."
 	curl -L -o "$(BUILD_ROOT)/$(HDF_zip)" "https://github.com/HDFGroup/hdf4/releases/download/hdf$(HDF_VERSION)/$(HDF_zip)"
 	cd "$(BUILD_ROOT)"; unzip -q "$(BUILD_ROOT)/$(HDF_zip)" -d "$(BUILD_ROOT)/hdf-$(HDF_VERSION)"
+	@echo "$(TO) HDF sources downloaded!"
 
 check_hdf_sources:
 	@if [[ ! -f "$(BUILD_ROOT)/$(HDF_zip)" ]] || [[ ! -d "$(HDF_SOURCE)" ]]; then \

--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -9,8 +9,8 @@ BUILD_NUMBER_TAIL=100
 ### build (drivers) root
 BUILD_ROOT=$(ROOTDIR_)/build-$(BASE_RID)
 
-# Jan 13, 2025
-GDAL_VERSION=3.10.1
+# Feb 14, 2025
+GDAL_VERSION=3.10.2
 GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 GDAL_REPO=https://github.com/OSGeo/gdal.git
 GDAL_COMMIT_VER=v$(GDAL_VERSION)


### PR DESCRIPTION
- Update to GDAL v3.10.2. See release notes https://github.com/OSGeo/gdal/blob/v3.10.2/NEWS.md