### PR TITLE
GDAL v3.11.0

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -176,6 +176,8 @@ jobs:
           name: formats-osx-${{ matrix.arch }}
           path: "tests/gdal-formats"
           merge-multiple: true
+      - run: |
+          ls -la ${{ github.workspace }}/tests/gdal-formats
 
       - name: Test packages
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -167,7 +167,9 @@ jobs:
           api-key-nuget: ${{ secrets.API_KEY_NUGET }}
           api-user-github: ${{ secrets.API_USER_GITHUB }}
           api-user-nuget: ${{ secrets.API_USER_NUGET }}
-
+      - name: Remove old formats
+        run: |
+          rm -rf ${{ github.workspace }}/tests/gdal-formats
       - uses: actions/download-artifact@v4
         name: Download artifact - formats
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -169,9 +169,11 @@ jobs:
           api-user-nuget: ${{ secrets.API_USER_NUGET }}
 
       - uses: actions/download-artifact@v4
+        name: Download artifact - formats
         with:
           name: formats-osx-${{ matrix.arch }}
           path: "tests/gdal-formats"
+          merge-multiple: true
 
       - name: Test packages
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -176,8 +176,6 @@ jobs:
           name: formats-osx-${{ matrix.arch }}
           path: "tests/gdal-formats"
           merge-multiple: true
-      - run: |
-          ls -la ${{ github.workspace }}/tests/gdal-formats
 
       - name: Test packages
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -168,6 +168,11 @@ jobs:
           api-user-github: ${{ secrets.API_USER_GITHUB }}
           api-user-nuget: ${{ secrets.API_USER_NUGET }}
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: formats-osx-${{ matrix.arch }}
+          path: "tests/gdal-formats"
+
       - name: Test packages
         run: |
           make -f test-makefile BUILD_ARCH=${{ matrix.arch }} BUILD_NUMBER_TAIL=${{ github.run_number }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,9 @@ jobs:
         with:
           pattern: packages-*
           path: nuget
-
+      - name: Remove old formats
+        run: |
+          rm -rf ${{ github.workspace }}/tests/gdal-formats
       - uses: actions/download-artifact@v4
         with:
           pattern: formats-*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
-  DOTNET_VERSION: "8.0.x"
+  DOTNET_VERSION: "9.0.x"
   IS_PRE_RELEASE: ${{ !(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/v')) }}
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,9 +120,11 @@ jobs:
         with:
           pattern: packages-*
           path: nuget
+
       - name: Remove old formats
         run: |
           rm -rf ${{ github.workspace }}/tests/gdal-formats
+
       - uses: actions/download-artifact@v4
         with:
           pattern: formats-*

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -176,9 +176,11 @@ jobs:
           path: nuget/
 
       - uses: actions/download-artifact@v4
+        name: Download artifact - formats
         with:
           name: formats-unix-${{ matrix.arch }}
           path: "tests/gdal-formats"
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -174,6 +174,9 @@ jobs:
         with:
           name: packages-unix-${{ matrix.arch }}
           path: nuget/
+      - name: Remove old formats
+        run: |
+          rm -rf ${{ github.workspace }}/tests/gdal-formats
 
       - uses: actions/download-artifact@v4
         name: Download artifact - formats

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -184,6 +184,8 @@ jobs:
           name: formats-unix-${{ matrix.arch }}
           path: "tests/gdal-formats"
           merge-multiple: true
+      - run: |
+          ls -la ${{ github.workspace }}/tests/gdal-formats
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -175,6 +175,11 @@ jobs:
           name: packages-unix-${{ matrix.arch }}
           path: nuget/
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: formats-unix-${{ matrix.arch }}
+          path: "tests/gdal-formats"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -184,8 +184,6 @@ jobs:
           name: formats-unix-${{ matrix.arch }}
           path: "tests/gdal-formats"
           merge-multiple: true
-      - run: |
-          ls -la ${{ github.workspace }}/tests/gdal-formats
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -130,6 +130,11 @@ jobs:
           api-user-nuget: ${{ secrets.API_USER_NUGET }}
           shell: pwsh
 
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: formats-win
+          path: "tests/gdal-formats"
+      
       - name: Test packages
         run: ./test.ps1 -buildNumberTail ${{ github.run_number }} -preRelease $${{ inputs.is-pre-release }}
         shell: pwsh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -131,9 +131,11 @@ jobs:
           shell: pwsh
 
       - uses: actions/download-artifact@v4
+        name: Download artifact - formats
         with:
           pattern: formats-win
           path: "tests/gdal-formats"
+          merge-multiple: true
       
       - name: Test packages
         run: ./test.ps1 -buildNumberTail ${{ github.run_number }} -preRelease $${{ inputs.is-pre-release }}

--- a/ci/Dockerfile.unix
+++ b/ci/Dockerfile.unix
@@ -23,7 +23,7 @@ RUN pip install cmake --upgrade
 # load cache from previous build
 COPY ci/cache*/dotnet* /usr/share/dotnet/ 
 
-ARG DOTNET_VERSION=8.0
+ARG DOTNET_VERSION=9.0
 ARG DOTNET_INSTALL_DIR=/build/ci/cache/.dotnet
 
 ENV PATH="${PATH}:/usr/share/dotnet"

--- a/ci/Dockerfile.unix.test
+++ b/ci/Dockerfile.unix.test
@@ -1,5 +1,5 @@
 # Runs tests from GDAL.NETCORE on Linux
-ARG DOTNET_VERSION=8.0
+ARG DOTNET_VERSION=9.0
 FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/sdk:$DOTNET_VERSION as base
 RUN apt-get update && apt-get install -y \
     build-essential

--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -70,8 +70,8 @@ LIBSHARED=$(PACKAGE_BUILD_ROOT)/$(__libshared)/$(RID)/$(__libshared)
 ##### GDAL source extended location
 GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 ##### Dotnet version for GDAL
-DOTNET_VERSION=8.0
-GDAL_CSHARP_VERSION=net8.0
+DOTNET_VERSION=9.0
+GDAL_CSHARP_VERSION=net9.0
 
 ##### SWIG executable and interface
 BASE_SWIG_=$(GDAL_ROOT)/swig

--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -9,8 +9,8 @@ BUILD_NUMBER_TAIL=100
 ### build (drivers) root
 BUILD_ROOT=$(ROOTDIR_)/build-$(BASE_RID)
 
-# Feb 14, 2025
-GDAL_VERSION=3.10.3
+# May 9, 2025
+GDAL_VERSION=3.11.0
 GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 GDAL_REPO=https://github.com/OSGeo/gdal.git
 GDAL_COMMIT_VER=v$(GDAL_VERSION)

--- a/shared/patch/CMakeLists.txt.patch
+++ b/shared/patch/CMakeLists.txt.patch
@@ -15,11 +15,11 @@ index ea9c5bb985..856bfa2ee4 100644
  if (DOTNET_FOUND)
    set(CSHARP_LIBRARY_VERSION
 -      "net6.0"
-+      "net8.0"
++      "net9.0"
        CACHE STRING ".NET version to be used for libraries")
    set(CSHARP_APPLICATION_VERSION
 -      "net6.0"
-+      "net8.0"
++      "net9.0"
        CACHE STRING ".NET version to be used for the sample Applications")
  else ()
    set(CSHARP_LIBRARY_VERSION

--- a/shared/templates/gdalcore.bundle.csproj.in
+++ b/shared/templates/gdalcore.bundle.csproj.in
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Platforms>arm64;x64</Platforms>
     <DebugType>portable</DebugType>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;net9.0;net461</TargetFrameworks>
     <Copyright>MaxRev © 2024</Copyright>
     <Authors>MaxRev</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/shared/templates/gdalcore.linuxruntime.bundle.csproj.in
+++ b/shared/templates/gdalcore.linuxruntime.bundle.csproj.in
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Platforms>arm64;x64</Platforms>
     <DebugType>portable</DebugType>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;net9.0;net461</TargetFrameworks>
     <Copyright>MaxRev © 2024</Copyright>
     <Authors>MaxRev</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -17,7 +17,7 @@
     <Version>${_PACKAGE_BUILD_NUMBER}</Version>
     <Description>GDAL (${_GDAL_VERSION}) minimal libraries package.
 Drivers included PROJ (${_PROJ_VERSION}), GEOS (${_GEOS_VERSION}), SQLITE3, CURL, JPEG, PNG, HDF4, HDF5, and others.
-Targets linux-arm64 and linux-x64 runtimes. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0
+Targets linux-arm64 and linux-x64 runtimes. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0, net9.0
     </Description>
     <PackageReleaseNotes>
 - GDAL ${_GDAL_VERSION}

--- a/shared/templates/gdalcore.linuxruntime.csproj.in
+++ b/shared/templates/gdalcore.linuxruntime.csproj.in
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Platform>${_BUILD_ARCH}</Platform>
     <DebugType>portable</DebugType>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;net9.0;net461</TargetFrameworks>
     <Copyright>MaxRev © 2024</Copyright>
     <Authors>MaxRev</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -17,7 +17,7 @@
     <Version>${_PACKAGE_BUILD_NUMBER}</Version>
     <Description>GDAL (${_GDAL_VERSION}) minimal libraries package.
 Drivers included PROJ (${_PROJ_VERSION}), GEOS (${_GEOS_VERSION}), SQLITE3, CURL, JPEG, PNG, HDF4, HDF5, and others.
-Targets linux-${_BUILD_ARCH} runtime. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0
+Targets linux-${_BUILD_ARCH} runtime. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0, net9.0
     </Description>
     <PackageReleaseNotes>
 - GDAL ${_GDAL_VERSION}

--- a/shared/templates/gdalcore.loader.csproj.in
+++ b/shared/templates/gdalcore.loader.csproj.in
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Platforms>x64;arm64</Platforms>
     <DebugType>portable</DebugType>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0;net9.0;net461</TargetFrameworks>
     <Copyright>MaxRev © 2024</Copyright>
     <Authors>MaxRev</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/shared/templates/gdalcore.macosruntime.bundle.csproj.in
+++ b/shared/templates/gdalcore.macosruntime.bundle.csproj.in
@@ -17,7 +17,7 @@
     <Version>${_PACKAGE_BUILD_NUMBER}</Version>
     <Description>GDAL (${_GDAL_VERSION}) minimal libraries package.
 Drivers included PROJ (${_PROJ_VERSION}), GEOS (${_GEOS_VERSION}), SQLITE3, CURL, JPEG, PNG, HDF4, HDF5, and others.
-Targets osx-arm64 and osx-x64 runtimes. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0
+Targets osx-arm64 and osx-x64 runtimes. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0, net9.0
     </Description>
     <PackageReleaseNotes>
 - GDAL ${_GDAL_VERSION}

--- a/shared/templates/gdalcore.macosruntime.csproj.in
+++ b/shared/templates/gdalcore.macosruntime.csproj.in
@@ -17,7 +17,7 @@
     <Version>${_PACKAGE_BUILD_NUMBER}</Version>
     <Description>GDAL (${_GDAL_VERSION}) minimal libraries package.
 Drivers included PROJ (${_PROJ_VERSION}), GEOS (${_GEOS_VERSION}), SQLITE3, CURL, JPEG, PNG, HDF4, HDF5, and others.
-Targets osx-${_BUILD_ARCH} runtime. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0
+Targets osx-${_BUILD_ARCH} runtime. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0, net9.0
     </Description>
     <PackageReleaseNotes>
 - GDAL ${_GDAL_VERSION}

--- a/shared/templates/gdalcore.windowsruntime.csproj.in
+++ b/shared/templates/gdalcore.windowsruntime.csproj.in
@@ -17,7 +17,7 @@
     <Version>${_PACKAGE_BUILD_NUMBER}</Version>
     <Description>GDAL (${_GDAL_VERSION}) minimal libraries package.
 Drivers included PROJ (${_PROJ_VERSION}), GEOS (${_GEOS_VERSION}), SQLITE3, CURL, JPEG, PNG, HDF4, HDF5, and others.
-Targets win-${_BUILD_ARCH} runtime. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0
+Targets win-${_BUILD_ARCH} runtime. Target Frameworks: netstandard[2.1|2.0], netframework 4.6.1+, net6.0, net7.0, net8.0, net9.0
     </Description>
     <PackageReleaseNotes>
 - GDAL ${_GDAL_VERSION}

--- a/tests/MaxRev.Gdal.Core.Tests.AzureFunctions/MaxRev.Gdal.Core.Tests.AzureFunctions.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.AzureFunctions/MaxRev.Gdal.Core.Tests.AzureFunctions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework> 
+    <TargetFramework>net9.0</TargetFramework> 
     <RootNamespace>MaxRev.Gdal.Core.Tests.AzureFunctions</RootNamespace>
     <Platforms>x64;arm64</Platforms>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/CommonTests.cs
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/CommonTests.cs
@@ -129,7 +129,7 @@ namespace GdalCore_XUnit
                 // check if the folder exists in CI environment
                 if (!Directory.Exists(ciFolder))
                 {
-                    ciFolder = folder; // fallback to the default folder
+                    ciFolder = folder; // fallback to the default path
                 }
                 var file = Path.Combine(ciFolder, $"gdal-formats-{ridTrimmed}-{type}.txt");
                 if (!File.Exists(file))

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/CommonTests.cs
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/CommonTests.cs
@@ -116,7 +116,7 @@ namespace GdalCore_XUnit
         {
             get => GetDriversInCurrentVersion();
         }
-        
+
         private static IEnumerable<object[]> GetDriversInCurrentVersion()
         {
             var folder = Extensions.GetTestDataFolder("../gdal-formats");
@@ -125,7 +125,13 @@ namespace GdalCore_XUnit
             var formats = new List<string>();
             foreach (var type in new[] { "raster", "vector" })
             {
-                var file = Path.Combine(folder, $"formats-{rid}/gdal-formats-{ridTrimmed}-{type}.txt");
+                var ciFolder = Path.Combine(folder, $"formats-{rid}");
+                // check if the folder exists in CI environment
+                if (!Directory.Exists(ciFolder))
+                {
+                    ciFolder = folder; // fallback to the default folder
+                }
+                var file = Path.Combine(ciFolder, $"gdal-formats-{ridTrimmed}-{type}.txt");
                 if (!File.Exists(file))
                 {
                     throw new FileNotFoundException($"File not found: {file}");

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>MaxRev.Gdal.Core.Tests.XUnit</RootNamespace>
     <NoWarn>NU1605</NoWarn>
     <IsPackable>false</IsPackable>

--- a/tests/MaxRev.Gdal.Core.Tests/Dockerfile
+++ b/tests/MaxRev.Gdal.Core.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as base
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS base
 WORKDIR /src
 COPY ["tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj", "MaxRev.Gdal.Core.Tests/"]
 COPY nuget nuget
@@ -9,7 +9,7 @@ FROM base AS publish
 WORKDIR /src
 RUN dotnet publish "MaxRev.Gdal.Core.Tests.csproj" -c Release -o /app/publish /p:UseAppHost=false
  
-FROM mcr.microsoft.com/dotnet/runtime:8.0 as final
+FROM mcr.microsoft.com/dotnet/runtime:9.0 AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "MaxRev.Gdal.Core.Tests.dll"]

--- a/tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Platforms>x64;arm64</Platforms>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <StartupObject>GdalCoreTest.Program</StartupObject>


### PR DESCRIPTION
- Update to GDAL v3.10.3. See release notes https://github.com/OSGeo/gdal/blob/v3.10.3/NEWS.md
- Using gdal-formats output for test cases
- Bump dotnet version to 9.0 for projects and CI