### PR TITLE
GDAL 3.11.1

### DIFF
--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -9,14 +9,14 @@ BUILD_NUMBER_TAIL=100
 ### build (drivers) root
 BUILD_ROOT=$(ROOTDIR_)/build-$(BASE_RID)
 
-# May 9, 2025
-GDAL_VERSION=3.11.0
+# Jul 1, 2025
+GDAL_VERSION=3.11.1
 GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 GDAL_REPO=https://github.com/OSGeo/gdal.git
 GDAL_COMMIT_VER=v$(GDAL_VERSION)
 
-# Apr 7, 2025
-PROJ_VERSION=9.6.0
+# Jun 6, 2025
+PROJ_VERSION=9.6.2
 PROJ_ROOT=$(BUILD_ROOT)/proj-source
 PROJ_REPO=https://github.com/OSGeo/PROJ.git
 PROJ_COMMIT_VER=$(PROJ_VERSION)
@@ -25,7 +25,7 @@ PROJ_COMMIT_VER=$(PROJ_VERSION)
 
 VCPKG_ROOT=$(BUILD_ROOT)/vcpkg
 VCPKG_REPO=https://github.com/microsoft/vcpkg.git
-VCPKG_COMMIT_VER=2025.04.09
+VCPKG_COMMIT_VER=2025.06.13
 
 # base requirements for all runtimes
 VCPKG_REQUIRE=geos "tiff[zstd,zip,jpeg,tools,lzma,cxx,webp]" curl "poppler[cairo,cms,zlib,glib,curl,private-api]"


### PR DESCRIPTION
Update to GDAL v3.11.1. See release notes: https://github.com/OSGeo/gdal/blob/v3.11.1/NEWS.md