### PR TITLE
GDAL 3.11.3

### DIFF
--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -9,8 +9,8 @@ BUILD_NUMBER_TAIL=100
 ### build (drivers) root
 BUILD_ROOT=$(ROOTDIR_)/build-$(BASE_RID)
 
-# Jul 1, 2025
-GDAL_VERSION=3.11.1
+# Jul 12, 2025
+GDAL_VERSION=3.11.3
 GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 GDAL_REPO=https://github.com/OSGeo/gdal.git
 GDAL_COMMIT_VER=v$(GDAL_VERSION)


### PR DESCRIPTION
Update to GDAL v3.11.3. See release notes: https://github.com/OSGeo/gdal/blob/v3.11.3/NEWS.md