### PR TITLE
Add files missing from package to force restore list

### DIFF
--- a/win/partials.psm1
+++ b/win/partials.psm1
@@ -383,7 +383,7 @@ function Copy-DependentDLLs {
                 $dllPath = $dllPath -replace "/", "\"
                     
                 # Skip system paths and include msodbcsql17.dll and other specific DLLs
-                $dllsToRestore = ("msodbcsql17.dll", "OpenCL.dll")
+                $dllsToRestore = ("msodbcsql17.dll", "OpenCL.dll", "libcrypto-3-x64.dll", "libssl-3-x64.dll")
                 if ($dllPath -notmatch "^\\c\\Windows" -or $dllsToRestore.Contains($dllName)) {
                     if ($dllPath -match "^\\([a-z])\\") {
                         $dllPath = $dllPath -replace "^\\([a-z])\\", { "$($matches[1].ToUpper()):\" }


### PR DESCRIPTION
In the latest version, there are 2 missing DLLs from the native windows package. I think this is because they are found in `C:\Windows\SYSTEM32` in the latest builds and are therefore excluded from being a dependent DLL.

There already exists a mechanism to allow files from `C:\Windows\SYSTEM32` through as a dependent DLL, such as `msodbcsql17.dll`.

These are hard coded at the moment, but it could be worth looking at making these a RegEx or glob so we could specify something like 'libcrypto*.dll'.

**Tests**

NA

**Closing issues**

closes #195 
