### PR TITLE
GDAL v3.12.0

### DIFF
--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -9,8 +9,8 @@ BUILD_NUMBER_TAIL=100
 ### build (drivers) root
 BUILD_ROOT=$(ROOTDIR_)/build-$(BASE_RID)
 
-# Nov 4, 2025
-GDAL_VERSION=3.11.5
+# Nov 8, 2025
+GDAL_VERSION=3.12.0
 GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 GDAL_REPO=https://github.com/OSGeo/gdal.git
 GDAL_COMMIT_VER=v$(GDAL_VERSION)

--- a/tests/MaxRev.Gdal.Core.Tests.AzureFunctions/MaxRev.Gdal.Core.Tests.AzureFunctions.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.AzureFunctions/MaxRev.Gdal.Core.Tests.AzureFunctions.csproj
@@ -7,7 +7,7 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Universal" Version="3.11.5" />
+    <PackageReference Include="MaxRev.Gdal.Universal" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests.XUnit/MaxRev.Gdal.Core.Tests.XUnit.csproj
@@ -7,7 +7,7 @@
     <Platforms>x64;arm64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Universal" Version="3.11.5" />
+    <PackageReference Include="MaxRev.Gdal.Universal" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj
+++ b/tests/MaxRev.Gdal.Core.Tests/MaxRev.Gdal.Core.Tests.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>MaxRev.Gdal.Core.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MaxRev.Gdal.Universal" Version="3.11.5" />
+    <PackageReference Include="MaxRev.Gdal.Universal" Version="3.12.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update to GDAL v3.12.0. See release notes: https://github.com/OSGeo/gdal/blob/v3.12.0/NEWS.md