### PR TITLE
GDAL v3.13.3

### DIFF
--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -15,8 +15,8 @@ GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 GDAL_REPO=https://github.com/OSGeo/gdal.git
 GDAL_COMMIT_VER=v$(GDAL_VERSION)
 
-# Mar 2, 2026
-PROJ_VERSION=9.8.0
+# Apr 10, 2026
+PROJ_VERSION=9.8.1
 PROJ_ROOT=$(BUILD_ROOT)/proj-source
 PROJ_REPO=https://github.com/OSGeo/PROJ.git
 PROJ_COMMIT_VER=$(PROJ_VERSION)

--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -9,8 +9,8 @@ BUILD_NUMBER_TAIL=100
 ### build (drivers) root
 BUILD_ROOT=$(ROOT_DIR)/build-$(BASE_RID)
 
-# Jul 22, 2026
-GDAL_VERSION=3.13.2
+# Aug 18, 2026
+GDAL_VERSION=3.13.3
 GDAL_ROOT=$(BUILD_ROOT)/gdal-source
 GDAL_REPO=https://github.com/OSGeo/gdal.git
 GDAL_COMMIT_VER=v$(GDAL_VERSION)

--- a/shared/vcpkg.json
+++ b/shared/vcpkg.json
@@ -9,7 +9,7 @@
     },
     {
       "name": "expat",
-      "version": "2.7.4"
+      "version": "2.7.5"
     }
   ],
   "features": {


### PR DESCRIPTION
Bumps GDAL to **3.13.3** (upstream bug-fix release, 2026-08-18), PROJ to **9.8.1**, and the expat override to **2.7.5**.

| dependency | from | to |
|---|---|---|
| GDAL | 3.13.2 | 3.13.3 |
| PROJ | 9.8.0 | 9.8.1 |
| expat (override) | 2.7.4 | 2.7.5 |

`GDAL_COMMIT_VER` resolves to the existing `v3.13.3` tag; PROJ's `9.8.1` tag follows the same unprefixed convention as before.

expat 2.7.5 brings three CVE fixes (CVE-2026-32776, -32777, -32778) and stays inside 2.7.x, so it does not disturb the GLIBC 2.35 floor: the floor problem is specific to 2.8.0+, which added CMake detection for `arc4random` (default AUTO) that resolves ON against a glibc 2.36 base. 2.7.x has no such option, so vcpkg's CMake build never links it. `ci/check-glibc-floor.sh` confirms the result on both arches.

`shared/patch/CMakeLists.txt.patch` still applies: `swig/csharp/CMakeLists.txt` is byte-identical between v3.13.2 and v3.13.3, verified with `git apply --check` against the 3.13.3 file. All three platforms apply this patch during the GDAL build.

Unchanged, deliberately:

- **arrow stays 23.0.1.** The `std::log2p1` reference does not exist at 23.0.1; it was introduced later and is still present at 25.0.1 behind `__apple_build_version__ && !__cpp_lib_bitops`, which is the Apple Clang misfire. apache/arrow#49841 remains open.
- **vcpkg baseline stays `2026.07.29`** - still the newest release tag.
- **HDF4 stays 4.3.1** - already the latest release.

The expat override still holds back 16 further CVE fixes across 2.8.0-2.8.3, 13 of them in 2.8.2. Taking those does not require accepting a higher floor: an overlay port passing `-DEXPAT_WITH_ARC4RANDOM=OFF -DEXPAT_WITH_ARC4RANDOM_BUF=OFF` would build current expat and keep 2.35. Left for a separate change.
