### PR TITLE
fix(ci): make the GLIBC floor gate fail closed; tag release builds reliably

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,10 +203,22 @@ jobs:
           author_email: ${{ secrets.COMMIT_EMAIL }}
           message: "List of drivers in current version [ci skip]"
           add: "${{ github.workspace }}/tests/gdal-formats/**"
-          tag: "v${{ env.PACKAGES_VERSION }} --force"
 
       - name: Push packages
         if: ${{  github.event.pull_request.merged == true || github.ref == 'refs/heads/main' || fromJson(needs.env-context.outputs.is-version-branch) }}
         run: |
           make -f push-packages-makefile PRERELEASE=${{ env.IS_PRE_RELEASE }} INCLUDE_CORE=1 \
             BUILD_NUMBER_TAIL=${{ github.run_number }} API_KEY_GITHUB=${{ secrets.API_KEY_GITHUB }} API_KEY_NUGET=${{ secrets.API_KEY_NUGET }}
+
+      # Tagging used to ride on the add-and-commit step above, which skips tagging when
+      # there is nothing to commit. The driver list is unchanged on most releases, so
+      # that silently produced untagged published versions (3.12.4.520, 3.13.2.549).
+      # Runs after the push so a release whose packages failed to publish is not tagged.
+      - name: Tag the release build
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          tag="v${{ env.PACKAGES_VERSION }}"
+          git tag -f "$tag" "${{ github.sha }}"
+          git push -f origin "refs/tags/$tag"
+          echo "tagged $tag at ${{ github.sha }}"

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -120,11 +120,13 @@ jobs:
       # Gates on the glibc floor in shared/GdalCore.opt before anything is uploaded,
       # so a dependency that raises the runtime requirement fails here instead of in
       # a user's loader. readelf reads foreign-arch ELF, so arm64 checks fine here.
+      # Every nupkg is passed, not just the runtime one: the CLI package ships native
+      # tools (gdalinfo, ogr2ogr) and is pushed too, so it needs the same gate. Packages
+      # with no ELF inside are simply skipped.
       - name: Verify GLIBC floor
         run: |
           chmod +x '${{ github.workspace }}/ci/check-glibc-floor.sh'
-          '${{ github.workspace }}/ci/check-glibc-floor.sh' \
-            nuget/MaxRev.Gdal.LinuxRuntime.Minimal.${{ matrix.arch }}.*.nupkg
+          '${{ github.workspace }}/ci/check-glibc-floor.sh' nuget/*.nupkg
 
       - name: Extract error artifacts (on failure)
         if: failure()

--- a/ci/check-glibc-floor.sh
+++ b/ci/check-glibc-floor.sh
@@ -3,42 +3,59 @@
 #
 # The floor is a support promise, not a build-image property: the build base may ship
 # a newer glibc than the oldest distro we still target, and a single dependency that
-# pulls in a newer symbol raises the runtime requirement for the whole package. That
-# is why shared/vcpkg.json pins expat (2.8.x uses arc4random, a glibc 2.36 symbol).
-# Without this check that kind of regression only surfaces as a user load failure.
+# pulls in a newer symbol raises the runtime requirement for the whole package.
+#
+# That is why shared/vcpkg.json holds expat below 2.8. expat has called arc4random in
+# xmlparse.c since well before 2.8 (it is there in 2.7.4), so the version alone is not
+# the issue; what changed is that 2.8.0 added CMake detection for it
+# (EXPAT_WITH_ARC4RANDOM, default AUTO). vcpkg builds expat with CMake, so 2.7.x never
+# links it, while 2.8.0+ resolves AUTO to ON against a glibc 2.36 base and imports
+# arc4random_buf@GLIBC_2.36. To un-pin, build expat with
+# -DEXPAT_WITH_ARC4RANDOM=OFF -DEXPAT_WITH_ARC4RANDOM_BUF=OFF and keep this gate green.
+#
+# This gate must never pass without having actually read symbol versions: a wrong path,
+# an unreadable file, or a readelf that fails all exit 2 rather than reporting success.
 #
 # Usage: check-glibc-floor.sh <path>...
-#   <path> may be a directory (scanned recursively) or a .nupkg (unpacked and scanned).
+#   <path> may be a directory (scanned recursively) or a .nupkg/.zip (unpacked, scanned).
 # Env:
 #   GLIBC_FLOOR  override the floor (default: GLIBC_FLOOR from shared/GdalCore.opt)
+# Exit: 0 = within floor, 1 = floor exceeded, 2 = could not determine (misuse/environment)
 
 set -euo pipefail
+
+die() { echo "error: $*" >&2; exit 2; }
 
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 opt_file="$script_dir/../shared/GdalCore.opt"
 
 floor="${GLIBC_FLOOR:-}"
+floor_source="GLIBC_FLOOR env"
 if [ -z "$floor" ] && [ -f "$opt_file" ]; then
-    floor=$(sed -n 's/^GLIBC_FLOOR=\([0-9][0-9.]*\).*/\1/p' "$opt_file" | head -1)
+    # grep first so a stray second definition cannot SIGPIPE sed under pipefail
+    floor=$(grep -m1 '^GLIBC_FLOOR=' "$opt_file" | cut -d= -f2 | tr -d '[:space:]' || true)
+    floor_source="shared/GdalCore.opt"
 fi
-if [ -z "$floor" ]; then
-    echo "error: no glibc floor configured (set GLIBC_FLOOR or add GLIBC_FLOOR= to shared/GdalCore.opt)" >&2
-    exit 2
-fi
+[ -n "$floor" ] || die "no glibc floor configured (set GLIBC_FLOOR or add GLIBC_FLOOR= to shared/GdalCore.opt)"
+
+# Validate whatever the source was. An unexpanded template or typo must not silently
+# disable the gate: sort -V ranks letters above digits, so a non-numeric floor would
+# make every binary compare as compliant.
+case "$floor" in
+    *[!0-9.]* | .* | *. | "") die "floor from $floor_source is not a version: '$floor'" ;;
+esac
+[[ "$floor" == *.* ]] || die "floor from $floor_source is not a version: '$floor'"
 
 if command -v readelf >/dev/null 2>&1; then
     readelf_bin=readelf
 elif command -v llvm-readelf >/dev/null 2>&1; then
     readelf_bin=llvm-readelf
 else
-    echo "error: readelf not found; install binutils" >&2
-    exit 2
+    die "readelf not found; install binutils"
 fi
+command -v unzip >/dev/null 2>&1 || die "unzip not found"
 
-if [ "$#" -eq 0 ]; then
-    echo "usage: $(basename "$0") <dir-or-nupkg>..." >&2
-    exit 2
-fi
+[ "$#" -gt 0 ] || { echo "usage: $(basename "$0") <dir-or-nupkg>..." >&2; exit 2; }
 
 work_dir=$(mktemp -d)
 trap 'rm -rf "$work_dir"' EXIT
@@ -53,15 +70,14 @@ for target in "$@"; do
             *.nupkg | *.zip)
                 dest="$work_dir/$(basename "$target").unpacked"
                 mkdir -p "$dest"
-                unzip -qq "$target" -d "$dest"
+                unzip -qq "$target" -d "$dest" || die "failed to unpack $target"
                 scan_roots+=("$dest")
                 echo "unpacked $(basename "$target")"
                 ;;
             *) scan_roots+=("$target") ;;
         esac
     else
-        echo "error: no such path: $target" >&2
-        exit 2
+        die "no such path: $target"
     fi
 done
 
@@ -74,62 +90,93 @@ version_max() {
     printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1
 }
 
+# Every glibc version this ELF requires, from two independent sources:
+#  - undefined (imported) symbols, which also give us names for diagnostics
+#  - the .gnu.version_r needs block, which additionally carries non-symbol ABI tags
+glibc_imports() {
+    "$readelf_bin" --wide --dyn-syms "$1" \
+        | awk '$7 == "UND"' \
+        | grep -oE '[A-Za-z_][A-Za-z0-9_]*@GLIBC_[0-9]+(\.[0-9]+)+' || true
+}
+glibc_needs() {
+    "$readelf_bin" --wide -V "$1" \
+        | awk '/Version needs section/ {inblk=1} /^Version (definition|symbols) section/ {inblk=0} inblk' \
+        | grep -oE 'Name: GLIBC_[A-Za-z0-9_.]+' | sed 's/^Name: //' || true
+}
+
 elf_count=0
+measured=0
 violations=0
+unreadable=0
+read_failures=0
+unknown_needs=""
 highest="0.0"
 highest_file=""
 
+find "${scan_roots[@]}" -type f -print0 > "$work_dir/files" \
+    || die "failed to enumerate files under: $*"
+
 while IFS= read -r -d '' file; do
+    # An unreadable file inside a package we just unpacked is an anomaly, not an
+    # absence of risk. Treating it as "not an ELF" would hide it from the count.
+    [ -r "$file" ] || { echo "unreadable: $file" >&2; unreadable=$((unreadable + 1)); continue; }
     is_elf "$file" || continue
     elf_count=$((elf_count + 1))
 
-    # Imported symbols carry a single @ (definitions use @@). Extract clean
-    # "name@GLIBC_x.y" tokens once; the raw readelf lines have a trailing " (N)"
-    # index that makes anchored matching against them fail.
-    imports=$("$readelf_bin" --wide --dyn-syms "$file" 2>/dev/null |
-        grep -oE '[A-Za-z_][A-Za-z0-9_]*@GLIBC_[0-9]+\.[0-9]+' |
-        grep -v '@@' | sort -u) || true
+    if ! imports=$(glibc_imports "$file"); then
+        echo "readelf --dyn-syms failed on $file" >&2
+        read_failures=$((read_failures + 1)); continue
+    fi
+    if ! needs=$(glibc_needs "$file"); then
+        echo "readelf -V failed on $file" >&2
+        read_failures=$((read_failures + 1)); continue
+    fi
 
-    [ -n "$imports" ] || continue
+    # Non-numeric requirements (e.g. GLIBC_ABI_DT_RELR, which implies glibc >= 2.36)
+    # cannot be compared, so refuse to judge rather than pass silently.
+    others=$(printf '%s\n' "$needs" | grep -vE '^GLIBC_[0-9]+(\.[0-9]+)+$' | grep -v '^$' || true)
+    [ -z "$others" ] || unknown_needs="$unknown_needs$file: $(echo "$others" | tr '\n' ' ')"$'\n'
 
-    required=$(printf '%s\n' "$imports" | sed 's/.*@GLIBC_//' | sort -uV) || true
+    required=$( { printf '%s\n' "$imports" | sed -n 's/.*@GLIBC_//p'
+                  printf '%s\n' "$needs" | sed -n 's/^GLIBC_\([0-9][0-9.]*\)$/\1/p'
+                } | grep -v '^$' | sort -uV || true)
+    [ -n "$required" ] || continue
+    measured=$((measured + 1))
+
     file_max=$(printf '%s\n' "$required" | tail -1)
-
     if [ "$(version_max "$file_max" "$highest")" != "$highest" ]; then
-        highest="$file_max"
-        highest_file="$file"
+        highest="$file_max"; highest_file="$file"
     fi
 
     if [ "$(version_max "$file_max" "$floor")" != "$floor" ]; then
         violations=$((violations + 1))
         echo
         echo "FAIL ${file#./} requires GLIBC_$file_max (floor is $floor)"
-        # Name the symbols that force it, so the offending dependency is obvious.
         while IFS= read -r over; do
             [ -n "$over" ] || continue
             [ "$(version_max "$over" "$floor")" != "$floor" ] || continue
             echo "  GLIBC_$over is required by:"
-            printf '%s\n' "$imports" |
-                grep -E "@GLIBC_${over//./\\.}\$" |
-                sed 's/@GLIBC_.*//' | sort -u | sed 's/^/    /' || true
+            printf '%s\n' "$imports" | grep -E "@GLIBC_${over//./\\.}\$" \
+                | sed 's/@GLIBC_.*//' | sort -u | sed 's/^/    /' || true
         done <<EOF
 $required
 EOF
     fi
-done < <(find "${scan_roots[@]}" -type f -print0)
+done < "$work_dir/files"
 
 echo
-if [ "$elf_count" -eq 0 ]; then
-    echo "error: no ELF binaries found under: $*" >&2
-    echo "       the check would pass vacuously, so treating this as a failure" >&2
-    exit 2
-fi
+[ "$unreadable" -eq 0 ] || die "$unreadable file(s) were unreadable; cannot certify the floor"
+[ "$read_failures" -eq 0 ] || die "readelf failed on $read_failures file(s); cannot certify the floor"
+[ "$elf_count" -gt 0 ] || die "no ELF binaries found under: $*"$'\n'"       refusing to report success without inspecting anything"
+[ "$measured" -gt 0 ] || die "found $elf_count ELF binaries but read no glibc requirement from any of them;"$'\n'"       readelf output is probably not being parsed as expected"
+[ -z "$unknown_needs" ] || die "unrecognised non-numeric glibc requirement(s):"$'\n'"$unknown_needs"
 
 if [ "$violations" -gt 0 ]; then
     echo "glibc floor check FAILED: $violations of $elf_count ELF binaries exceed GLIBC_$floor"
     exit 1
 fi
 
-echo "glibc floor check passed: $elf_count ELF binaries, highest requirement GLIBC_$highest (floor $floor)"
+echo "glibc floor check passed: $measured of $elf_count ELF binaries carry glibc requirements,"
+echo "  highest is GLIBC_$highest (floor $floor, from $floor_source)"
 [ -n "$highest_file" ] && echo "  set by ${highest_file#./}"
 exit 0

--- a/shared/GdalCore.opt
+++ b/shared/GdalCore.opt
@@ -34,7 +34,8 @@ VCPKG_COMMIT_VER=9e593bb18ea69cc5095e012465dcd675a822ed0d
 # Oldest glibc the shipped Linux packages must keep loading on (Ubuntu 22.04).
 # The build base may be newer, so this is a support promise the build has to respect:
 # one dependency pulling in a newer symbol raises the requirement for every package.
-# Enforced per-arch by ci/check-glibc-floor.sh; it is why expat is pinned in vcpkg.json.
+# Enforced per-arch by ci/check-glibc-floor.sh; also why vcpkg.json holds expat below
+# 2.8 (see that script's header for the actual mechanism, which is not the version).
 GLIBC_FLOOR=2.35
 
 VCPKG_CLEANUP=buildtrees downloads packages installed


### PR DESCRIPTION
Two CI correctness fixes.

## 1. The GLIBC floor gate could pass without inspecting anything

Three paths produced a pass with a non-compliant binary present:

- `readelf` failing, or succeeding with no output, was swallowed by `2>/dev/null` plus `|| true`. Every binary could be skipped while the file count still made the run look inspected, giving `passed ... GLIBC_0.0` and exit 0. Reachable via a corrupt ELF, a binutils that rejects the foreign arch (arm64 is checked on an x64 runner), or `llvm-readelf` output drift.
- A non-numeric `GLIBC_FLOOR` disabled the comparison, because `sort -V` ranks letters above digits. An unexpanded template printed the ceiling as 2.36 and still exited 0.
- An unreadable file was treated as "not an ELF" and dropped from the count entirely.

`readelf` failures and unreadable files are now hard errors, the floor is format-validated whatever its source, and a pass additionally requires that at least one binary actually yielded a glibc requirement.

**Coverage.** The gate only received the runtime nupkg, but `MaxRev.Gdal.CLI.linux-<arch>` ships native tools (gdalinfo, ogr2ogr) and is pushed as well, so a floor regression there shipped unblocked. It now receives every nupkg; packages without ELF are skipped. On this branch that takes the gate from 73 to **102 binaries** per arch.

Also reads `.gnu.version_r` alongside `--dyn-syms` so a non-symbol ABI requirement such as `GLIBC_ABI_DT_RELR` cannot slip past, and refuses to judge unrecognised non-numeric requirements rather than passing them. Symbol filtering keys on the `UND` column instead of an `@@` pattern that could never match. Three-component versions are no longer truncated. Exit codes: 0 within floor, 1 exceeded, 2 could not determine.

The expat comment is corrected: expat has called `arc4random` since before 2.8, so the version is not the mechanism. 2.8.0 added CMake detection for it (`EXPAT_WITH_ARC4RANDOM`, default AUTO) which resolves ON against glibc 2.36, while 2.7.x has no such option so vcpkg's CMake build never links it. The header records the `-DEXPAT_WITH_ARC4RANDOM=OFF` route to un-pinning.

## 2. Release builds were not being tagged

Tagging rode on the `Commit changes` step's `tag:` input, but `EndBug/add-and-commit` skips tagging when there is nothing to commit. The driver-formats list is unchanged on most releases, so the step logged `Working tree clean. Nothing to commit.` / `tagged: false` while `Push packages` published anyway. That is how **3.12.4.520** and **3.13.2.549** both reached NuGet untagged and without a GitHub release.

The unreliable input is dropped in favour of an explicit tag step, placed after the package push so a release whose packages failed to publish is not tagged. It points at `github.sha`, matching where existing release tags sit (`v3.13.1.534` is on the merge commit, not on a formats commit). It needs an explicit `working-directory` because the job defaults to `unix/`.

This path is gated on `push` to `refs/heads/main`, so PR CI cannot exercise it; its first real run is the next merge to main.

## Verification

Floor gate, in `debian:12` against purpose-built shared objects (one importing only `memcpy`, one importing `arc4random_buf@GLIBC_2.36`):

- nine pre-existing behaviours unchanged (pass, fail-with-symbol-named, equal-version boundary, empty dir, missing path, floor-from-opt-file, nupkg unpacking, mixed input, no-args)
- each of the three false-pass paths now exits 2, including a stubbed `readelf` that fails on every file and one that silently succeeds
- a violation planted only in a CLI-style package is caught
- a package containing no ELF at all exits 2 rather than passing

CI on this branch was green at 15/15 before the tagging commit, with the gate reporting `101 of 102 ELF binaries` at ceiling GLIBC_2.35 on both arches. shellcheck clean at style level.
